### PR TITLE
Put correct git URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is a Model Context Protocol (MCP) server implementation for Alpaca's Tradin
 
 1. Clone the repository and move to the repository:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/alpaca-mcp-server.git
+   git clone https://github.com/alpacahq/alpaca-mcp-server.git
    cd alpaca-mcp-server
    ```
 


### PR DESCRIPTION
- README instructions has incomplete `git clone` URL
- Correcting it to be "alpacahq" instead of "YOUR_USERNAME"