### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.env
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD ["python", "alpaca_mcp_server.py"]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,32 @@ To enable **live trading with real funds**, update the following configuration f
    PAPER = False
    ```
 
+### Docker Usage
+
+```json
+{
+  "mcpServers": {
+    "alpaca": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "ALPACA_API_KEY",
+        "-e",
+        "ALPACA_SECRET_KEY",
+        "ghcr.io/chand1012/alpaca-mcp-server"
+      ],
+      "env": {
+        "ALPACA_API_KEY": "your_alpaca_api_key_for_live_account",
+        "ALPACA_SECRET_KEY": "your_alpaca_secret_key_for_live_account"
+      }
+    }
+  }
+}
+```
+
 ## Available Tools
 
 ### Account & Positions


### PR DESCRIPTION
I always find that I'm more inclined to use an MCP if its easy to configure. Given that mosts devs have Docker installed on their system, I figured it would be a good way to get people up and running quickly, no cloning or installation required. Worked great in my Cursor editor!