### PR TITLE
Fixes bug in alpaca_mcp_server.py to enable live trading

### DIFF
--- a/alpaca_mcp_server.py
+++ b/alpaca_mcp_server.py
@@ -159,7 +159,7 @@ if not TRADE_API_KEY or not TRADE_API_SECRET:
     raise ValueError("Alpaca API credentials not found in environment variables.")
 
 # Convert string to boolean
-ALPACA_PAPER_TRADE_BOOL = ALPACA_PAPER_TRADE.lower() in ['true', '1', 'yes', 'on']
+ALPACA_PAPER_TRADE_BOOL = ALPACA_PAPER_TRADE.lower() not in ['false', '0', 'no', 'off']
 
 # Initialize clients
 # For trading


### PR DESCRIPTION
The paper trade environment variable is a string not a boolean, This change converts the string to boolean