### PR TITLE
Add --no-dns-protection flag for LAN/self-hosted deployments

### DIFF
--- a/src/alpaca_mcp_server/cli.py
+++ b/src/alpaca_mcp_server/cli.py
@@ -149,12 +149,19 @@ def init(api_key: Optional[str], secret_key: Optional[str],
     help='Allowed hosts for cloud (comma-separated, env: ALLOWED_HOSTS)'
 )
 @click.option(
+    '--no-dns-protection',
+    is_flag=True,
+    default=False,
+    envvar='NO_DNS_PROTECTION',
+    help='Disable DNS rebinding protection (for trusted LAN/self-hosted deployments)'
+)
+@click.option(
     '--config-file',
     type=click.Path(path_type=Path),
     help='Path to .env configuration file (default: .env in current directory)'
 )
-def serve(transport: str, host: str, port: int, allowed_hosts: str, 
-          config_file: Optional[Path]):
+def serve(transport: str, host: str, port: int, allowed_hosts: str,
+          no_dns_protection: bool, config_file: Optional[Path]):
     """
     Start the Alpaca MCP server.
 
@@ -189,7 +196,11 @@ def serve(transport: str, host: str, port: int, allowed_hosts: str,
                 click.echo()
                 click.echo("Update the credentials above or export them as environment variables.")
             sys.exit(1)
-        
+
+        # When --no-dns-protection is set, auto-switch default host to 0.0.0.0
+        if no_dns_protection and host == '127.0.0.1':
+            host = '0.0.0.0'
+
         # Display startup information (unless in stdio mode for MCP clients)
         if transport != "stdio":
             click.echo("Starting Alpaca MCP Server")
@@ -198,7 +209,10 @@ def serve(transport: str, host: str, port: int, allowed_hosts: str,
             click.echo(f"   Config: {source_hint}")
             if transport == "streamable-http":
                 click.echo(f"   URL: http://{host}:{port}")
-                if allowed_hosts:
+                if no_dns_protection:
+                    click.echo("   WARNING: DNS rebinding protection DISABLED")
+                    click.echo("   Only use on trusted networks!")
+                elif allowed_hosts:
                     click.echo(f"   Allowed Hosts: {allowed_hosts}")
                 else:
                     click.echo("   DNS protection: localhost only")
@@ -210,7 +224,8 @@ def serve(transport: str, host: str, port: int, allowed_hosts: str,
             transport=transport,
             host=host,
             port=port,
-            allowed_hosts=allowed_hosts
+            allowed_hosts=allowed_hosts,
+            no_dns_protection=no_dns_protection
         )
 
     except KeyboardInterrupt:

--- a/src/alpaca_mcp_server/server.py
+++ b/src/alpaca_mcp_server/server.py
@@ -3430,25 +3430,34 @@ class AlpacaMCPServer:
         transport: str = "stdio",
         host: str = "127.0.0.1",
         port: int = 8000,
-        allowed_hosts: str = ""
+        allowed_hosts: str = "",
+        no_dns_protection: bool = False
     ) -> None:
         """Run the Alpaca's MCP Server.
-        
+
         Use stdio (default) for local, or streamable-http with --allowed-hosts for cloud.
         """
         if transport == "streamable-http":
             # Configure FastMCP settings for HTTP transport
             mcp.settings.host = host
             mcp.settings.port = port
-            
+
             # Configure transport security for DNS rebinding protection
             from mcp.server.transport_security import TransportSecuritySettings
-            
-            if allowed_hosts:
-                # Option 2: Enable protection with specific allowed hosts (RECOMMENDED)
+
+            if no_dns_protection:
+                # Explicitly disable DNS rebinding protection
+                # for trusted LAN / self-hosted deployments
+                mcp.settings.transport_security = TransportSecuritySettings(
+                    enable_dns_rebinding_protection=False
+                )
+                print("DNS rebinding protection DISABLED", file=sys.stderr)
+
+            elif allowed_hosts:
+                # Enable protection with specific allowed hosts (RECOMMENDED)
                 # Parse comma-separated host list
                 hosts_list = [h.strip() for h in allowed_hosts.split(",") if h.strip()]
-                
+
                 # For each host, add both the bare hostname and wildcard port version
                 # This handles both "Host: example.com" and "Host: example.com:8000"
                 all_allowed_hosts = []
@@ -3460,35 +3469,35 @@ class AlpacaMCPServer:
                     else:
                         # Already has port or is a pattern, add as-is
                         all_allowed_hosts.append(h)
-                
+
                 # Always include localhost variants for local testing
                 all_allowed_hosts.extend([
                     "127.0.0.1", "127.0.0.1:*",
                     "localhost", "localhost:*",
                     "[::1]", "[::1]:*"
                 ])
-                
+
                 # Generate allowed origins for CORS (both http and https)
                 allowed_origins = (
                     [f"https://{h}" for h in hosts_list] +
                     [f"http://{h}" for h in hosts_list] +
                     ["http://127.0.0.1:*", "http://localhost:*"]
                 )
-                
+
                 mcp.settings.transport_security = TransportSecuritySettings(
                     enable_dns_rebinding_protection=True,
                     allowed_hosts=all_allowed_hosts,
                     allowed_origins=allowed_origins
                 )
-                
+
                 print(f"DNS protection enabled: {', '.join(hosts_list)}", file=sys.stderr)
-                
+
             else:
                 print("DNS protection: localhost only", file=sys.stderr)
-            
+
             # Start the server with streamable HTTP transport
             mcp.run(transport="streamable-http")
-            
+
         else:
             # Use stdio transport (default)
             mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary

- Adds `--no-dns-protection` CLI flag (and `NO_DNS_PROTECTION` env var) to the `serve` command
- When set, disables `TransportSecuritySettings` DNS rebinding protection entirely
- Auto-switches default host from `127.0.0.1` to `0.0.0.0` when the flag is used
- Prints a clear warning at startup when running without protection

## Motivation

Many users self-host MCP servers on trusted LANs where DNS rebinding protection blocks legitimate access from other machines on the network. Currently the only workaround is `--allowed-hosts` with explicit hostnames, which is cumbersome for home/lab networks with many clients. This provides a simple opt-out for trusted environments.

## Usage

```bash
# HTTP server accessible on LAN, no DNS protection
alpaca-mcp-server serve --transport streamable-http --no-dns-protection

# Via environment variable (useful for Docker)
NO_DNS_PROTECTION=1 alpaca-mcp-server serve --transport streamable-http
```

## Changes

- `cli.py`: New `--no-dns-protection` click option, auto-host switching, startup warning
- `server.py`: `no_dns_protection` parameter in `AlpacaMCPServer.run()`, sets `enable_dns_rebinding_protection=False`

## Test plan

- [x] `--help` shows the new flag
- [x] stdio transport still works (default, unaffected)
- [x] `--transport streamable-http --no-dns-protection` starts on `0.0.0.0:8000`
- [x] MCP initialize handshake succeeds from network client
- [x] `--allowed-hosts` path unchanged when `--no-dns-protection` is not set