### PR TITLE
Fix expiration parse error message

### DIFF
--- a/src/alpaca_mcp_server/helpers.py
+++ b/src/alpaca_mcp_server/helpers.py
@@ -4,7 +4,6 @@ from datetime import datetime, date, timedelta, timezone
 from typing import Any, Dict, List, Optional, Union, Tuple
 from zoneinfo import ZoneInfo
 from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
-from alpaca.trading.enums import OrderClass, OrderSide, TimeInForce
 from alpaca.trading.models import Order
 from alpaca.trading.requests import LimitOrderRequest, MarketOrderRequest, OptionLegRequest
 from alpaca.trading.enums import (
@@ -260,7 +259,7 @@ def _parse_expiration_expression(expression: str) -> Dict[str, Any]:
             return {"error": f"Invalid date in expression: {str(e)}"}
 
     return {
-        "error": "Unable to parse expression '{expression}'. Supported formats: 'week of September 7, 2025', 'month of December 2025', 'September 7, 2025'",
+        "error": f"Unable to parse expression '{expression}'. Supported formats: 'week of September 7, 2025', 'month of December 2025', 'September 7, 2025'",
     }
 
 


### PR DESCRIPTION
## What changed
- Fix the fallback expiration parse error message to interpolate the user expression.
- Drop a duplicate enum import to keep the module tidy.

## Why
- The current error path shows a literal "{expression}" placeholder, which is confusing for users.
- Removing redundant imports reduces noise without changing behavior.

## Testing
- Tests: not run (no tests found)
