### PR TITLE
fix: add configurable Alpaca request timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@
 ALPACA_API_KEY = "your_alpaca_api_key_for_paper_account"
 ALPACA_SECRET_KEY = "your_alpaca_secret_key_for_paper_account"
 ALPACA_PAPER_TRADE = True # True for paper trading, False for live trading
+ALPACA_HTTP_TIMEOUT_SECONDS = 10 # Fail slow Alpaca REST requests faster
 
 TRADE_API_URL = None
 TRADE_API_WSS = None

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Method 2: Manually Update
 ALPACA_API_KEY = "your_alpaca_api_key_for_live_account"
 ALPACA_SECRET_KEY = "your_alpaca_secret_key_for_live_account"
 ALPACA_PAPER_TRADE = False
+ALPACA_HTTP_TIMEOUT_SECONDS = 10
 TRADE_API_URL = None
 TRADE_API_WSS = None
 DATA_API_URL = None
@@ -1042,6 +1043,7 @@ Replace `your_alpaca_api_key` and `your_alpaca_secret_key` with your actual Alpa
 - **uv/uvx not found**: Install uv from the official guide (https://docs.astral.sh/uv/getting-started/installation/) and then restart your terminal so `uv`/`uvx` are on PATH.
 - **`.env` not applied**: Ensure the server starts in the same directory as `.env`. Remember MCP client `env` overrides `.env`.
 - **Credentials missing**: Set `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` in `.env` or in the client's `env` block. Paper mode default is `ALPACA_PAPER_TRADE = True`.
+- **Requests hang too long**: Set `ALPACA_HTTP_TIMEOUT_SECONDS` in `.env` or the client's `env` block to fail slow Alpaca REST requests faster. Default is `10`.
 - **Client didn’t pick up new config**: Restart the client (Cursor, Claude Desktop, VS Code) after changes.
 - **HTTP port conflicts**: If using `--transport streamable-http`, change `--port` to a free port.
 

--- a/install.py
+++ b/install.py
@@ -349,6 +349,7 @@ def prompt_for_api_keys() -> Dict[str, str]:
         'ALPACA_API_KEY': api_key,
         'ALPACA_SECRET_KEY': secret_key,
         'ALPACA_PAPER_TRADE': paper_trade_value,
+        'ALPACA_HTTP_TIMEOUT_SECONDS': '10',
         'TRADE_API_URL': 'None',
         'TRADE_API_WSS': 'None',
         'DATA_API_URL': 'None',
@@ -371,6 +372,7 @@ ALPACA_SECRET_KEY = "{api_config['ALPACA_SECRET_KEY']}"
 
 # Trading Configuration
 ALPACA_PAPER_TRADE = {api_config['ALPACA_PAPER_TRADE']}
+ALPACA_HTTP_TIMEOUT_SECONDS = {api_config['ALPACA_HTTP_TIMEOUT_SECONDS']}
 
 # API Endpoints (leave as None for defaults)
 TRADE_API_URL = {api_config['TRADE_API_URL']}

--- a/src/alpaca_mcp_server/config.py
+++ b/src/alpaca_mcp_server/config.py
@@ -46,6 +46,7 @@ class ConfigManager:
             'api_key': os.getenv('ALPACA_API_KEY', ''),
             'secret_key': os.getenv('ALPACA_SECRET_KEY', ''),
             'paper_trade': os.getenv('ALPACA_PAPER_TRADE', 'True').lower() == 'true',
+            'http_timeout_seconds': os.getenv('ALPACA_HTTP_TIMEOUT_SECONDS', '10'),
             'trade_api_url': os.getenv('TRADE_API_URL') if os.getenv('TRADE_API_URL') not in ['None', None, ''] else None,
             'trade_api_wss': os.getenv('TRADE_API_WSS') if os.getenv('TRADE_API_WSS') not in ['None', None, ''] else None,
             'data_api_url': os.getenv('DATA_API_URL') if os.getenv('DATA_API_URL') not in ['None', None, ''] else None,
@@ -117,6 +118,7 @@ ALPACA_SECRET_KEY={secret_key}
 # Trading Configuration
 # True = Paper trading (safe for testing), False = Live trading (real money)
 ALPACA_PAPER_TRADE={paper_trade}
+ALPACA_HTTP_TIMEOUT_SECONDS=10
 
 # API Endpoints (leave as None to use Alpaca defaults)
 TRADE_API_URL=None
@@ -162,5 +164,6 @@ STREAM_DATA_WSS=None
 - API Key: {api_key_display}
 - Secret Key: {secret_key_display}
 - Paper Trading: {config['paper_trade']}
+- HTTP Timeout Seconds: {config['http_timeout_seconds']}
 - Config File: {self.env_file}
 - File Exists: {self.env_file.exists()}"""

--- a/src/alpaca_mcp_server/server.py
+++ b/src/alpaca_mcp_server/server.py
@@ -26,6 +26,7 @@ from typing import Dict, Any, List, Optional, Union
 from pathlib import Path
 
 from dotenv import load_dotenv
+from requests.exceptions import Timeout as RequestsTimeout
 
 from alpaca.common.enums import SupportedCurrencies
 from alpaca.common.exceptions import APIError
@@ -135,6 +136,52 @@ except ImportError:
 
 from mcp.server.fastmcp import FastMCP
 
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 10.0
+
+
+def _get_request_timeout_seconds() -> float:
+    """Read the Alpaca HTTP timeout from the environment with a safe fallback."""
+    raw_value = os.getenv("ALPACA_HTTP_TIMEOUT_SECONDS", "").strip()
+    if not raw_value:
+        return DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+    try:
+        timeout_seconds = float(raw_value)
+    except ValueError:
+        return DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+    if timeout_seconds <= 0:
+        return DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+    return timeout_seconds
+
+
+def _format_timeout_error(timeout_seconds: float) -> str:
+    return (
+        f"Alpaca API request timed out after {timeout_seconds:g}s. "
+        "Set ALPACA_HTTP_TIMEOUT_SECONDS to a larger value if needed."
+    )
+
+
+class AlpacaRequestTimeoutError(TimeoutError):
+    """Raised when an Alpaca SDK request exceeds the configured timeout."""
+
+
+class RequestTimeoutMixin:
+    """Inject a default timeout into Alpaca SDK REST requests."""
+
+    def _one_request(self, method: str, url: str, opts: dict, retry: int) -> dict:
+        request_opts = dict(opts)
+        timeout_seconds = _get_request_timeout_seconds()
+        request_opts.setdefault("timeout", timeout_seconds)
+
+        try:
+            return super()._one_request(method, url, request_opts, retry)
+        except RequestsTimeout as exc:
+            raise AlpacaRequestTimeoutError(
+                _format_timeout_error(timeout_seconds)
+            ) from exc
+
 # Configure Python path for local imports (UserAgentMixin)
 current_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = Path(current_dir).parent.parent
@@ -146,18 +193,52 @@ if github_core_path.exists() and str(github_core_path) not in sys.path:
 try:
     from user_agent_mixin import UserAgentMixin
     # Define new classes using the mixin
-    class TradingClientSigned(UserAgentMixin, TradingClient): pass
-    class StockHistoricalDataClientSigned(UserAgentMixin, StockHistoricalDataClient): pass
-    class OptionHistoricalDataClientSigned(UserAgentMixin, OptionHistoricalDataClient): pass
-    class CorporateActionsClientSigned(UserAgentMixin, CorporateActionsClient): pass
-    class CryptoHistoricalDataClientSigned(UserAgentMixin, CryptoHistoricalDataClient): pass
+    class TradingClientSigned(RequestTimeoutMixin, UserAgentMixin, TradingClient):
+        pass
+
+    class StockHistoricalDataClientSigned(
+        RequestTimeoutMixin, UserAgentMixin, StockHistoricalDataClient
+    ):
+        pass
+
+    class OptionHistoricalDataClientSigned(
+        RequestTimeoutMixin, UserAgentMixin, OptionHistoricalDataClient
+    ):
+        pass
+
+    class CorporateActionsClientSigned(
+        RequestTimeoutMixin, UserAgentMixin, CorporateActionsClient
+    ):
+        pass
+
+    class CryptoHistoricalDataClientSigned(
+        RequestTimeoutMixin, UserAgentMixin, CryptoHistoricalDataClient
+    ):
+        pass
 except ImportError:
     # Fallback to unsigned clients if mixin not available
-    TradingClientSigned = TradingClient
-    StockHistoricalDataClientSigned = StockHistoricalDataClient
-    OptionHistoricalDataClientSigned = OptionHistoricalDataClient
-    CorporateActionsClientSigned = CorporateActionsClient
-    CryptoHistoricalDataClientSigned = CryptoHistoricalDataClient
+    class TradingClientSigned(RequestTimeoutMixin, TradingClient):
+        pass
+
+    class StockHistoricalDataClientSigned(
+        RequestTimeoutMixin, StockHistoricalDataClient
+    ):
+        pass
+
+    class OptionHistoricalDataClientSigned(
+        RequestTimeoutMixin, OptionHistoricalDataClient
+    ):
+        pass
+
+    class CorporateActionsClientSigned(
+        RequestTimeoutMixin, CorporateActionsClient
+    ):
+        pass
+
+    class CryptoHistoricalDataClientSigned(
+        RequestTimeoutMixin, CryptoHistoricalDataClient
+    ):
+        pass
 
 # Load environment variables
 load_dotenv()

--- a/tests/test_request_timeout.py
+++ b/tests/test_request_timeout.py
@@ -1,0 +1,73 @@
+import pytest
+from requests.exceptions import Timeout as RequestsTimeout
+
+from alpaca_mcp_server import server
+
+
+class _RecordingBase:
+    def _one_request(self, method: str, url: str, opts: dict, retry: int) -> dict:
+        return {
+            "method": method,
+            "url": url,
+            "opts": opts,
+            "retry": retry,
+        }
+
+
+class _TimeoutBase:
+    def _one_request(self, method: str, url: str, opts: dict, retry: int) -> dict:
+        raise RequestsTimeout("timed out")
+
+
+class _RecordingClient(server.RequestTimeoutMixin, _RecordingBase):
+    pass
+
+
+class _TimeoutClient(server.RequestTimeoutMixin, _TimeoutBase):
+    pass
+
+
+def test_get_request_timeout_seconds_defaults_when_unset(monkeypatch):
+    monkeypatch.delenv("ALPACA_HTTP_TIMEOUT_SECONDS", raising=False)
+
+    assert server._get_request_timeout_seconds() == server.DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+
+def test_get_request_timeout_seconds_defaults_when_invalid(monkeypatch):
+    monkeypatch.setenv("ALPACA_HTTP_TIMEOUT_SECONDS", "not-a-number")
+    assert server._get_request_timeout_seconds() == server.DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+    monkeypatch.setenv("ALPACA_HTTP_TIMEOUT_SECONDS", "0")
+    assert server._get_request_timeout_seconds() == server.DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+
+def test_request_timeout_mixin_injects_default_timeout(monkeypatch):
+    monkeypatch.setenv("ALPACA_HTTP_TIMEOUT_SECONDS", "7.5")
+
+    client = _RecordingClient()
+    result = client._one_request("GET", "https://example.com", {"headers": {}}, 0)
+
+    assert result["opts"]["timeout"] == 7.5
+
+
+def test_request_timeout_mixin_preserves_explicit_timeout(monkeypatch):
+    monkeypatch.setenv("ALPACA_HTTP_TIMEOUT_SECONDS", "7.5")
+
+    client = _RecordingClient()
+    result = client._one_request(
+        "GET",
+        "https://example.com",
+        {"headers": {}, "timeout": 2},
+        0,
+    )
+
+    assert result["opts"]["timeout"] == 2
+
+
+def test_request_timeout_mixin_raises_clear_timeout_error(monkeypatch):
+    monkeypatch.setenv("ALPACA_HTTP_TIMEOUT_SECONDS", "7.5")
+
+    client = _TimeoutClient()
+
+    with pytest.raises(server.AlpacaRequestTimeoutError, match="timed out after 7.5s"):
+        client._one_request("GET", "https://example.com", {"headers": {}}, 0)


### PR DESCRIPTION
## Summary
- add a configurable `ALPACA_HTTP_TIMEOUT_SECONDS` setting with a safe default of 10 seconds
- inject the timeout into Alpaca SDK REST clients used by the MCP server
- surface a clearer timeout error when Alpaca requests hang
- document the new setting in generated env/config flows and add focused tests

## Why
The server currently relies on the Alpaca Python SDK's default `requests` behavior, which does not set an explicit request timeout. When an Alpaca API call stalls, MCP tool calls can hang until the client itself times out. This makes failures look like generic MCP timeouts instead of actionable Alpaca request failures.

## Implementation notes
- the timeout behavior is scoped to this server via a local mixin rather than a global `requests` monkeypatch
- explicit timeouts passed by upstream code are preserved
- invalid or missing `ALPACA_HTTP_TIMEOUT_SECONDS` values fall back to the default

## Testing
- `uv run --extra dev python -m pytest tests/test_request_timeout.py`
- `uv run python -m compileall src tests`

## Notes
I did not run a full repo-wide Ruff pass because the current branch already has unrelated lint findings outside this change set.