### PR TITLE
fix: Render deploy — correct Docker CMD and HTTP defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,5 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ENV PATH="/app/.venv/bin:$PATH"
 
-CMD ["alpaca-mcp-server", "serve"]
-
-# For cloud deployment
-# CMD ["alpaca-mcp-server", "serve", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]
+# HTTP transport for remote MCP clients (e.g. ChatGPT). Bind all interfaces; use Render's $PORT via cli default.
+CMD ["alpaca-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0"]

--- a/charts/alpaca-mcp-server/values.yaml
+++ b/charts/alpaca-mcp-server/values.yaml
@@ -16,7 +16,7 @@ image:
 # This sets the command to run in the container more information can be found here: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
 command: ["alpaca-mcp-server"]
 # This sets the arguments to pass to the command more information can be found here: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
-args: ["serve", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]
+args: ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/src/alpaca_mcp_server/cli.py
+++ b/src/alpaca_mcp_server/cli.py
@@ -11,6 +11,15 @@ import click
 
 from . import __version__
 
+# Older Docker/Helm configs invoked `alpaca-mcp-server serve ...`; the CLI has no subcommands.
+if len(sys.argv) > 1 and sys.argv[1] == "serve":
+    sys.argv.pop(1)
+
+
+def _default_port() -> int:
+    """HTTP bind port; honors Render/Fly-style ``PORT`` when ``--port`` is omitted."""
+    return int(os.environ.get("PORT", "8000"))
+
 
 @click.command()
 @click.version_option(version=__version__, prog_name="alpaca-mcp-server")
@@ -21,7 +30,12 @@ from . import __version__
     help="Transport protocol (default: stdio)",
 )
 @click.option("--host", default="127.0.0.1", help="Host to bind (HTTP transport only)")
-@click.option("--port", type=int, default=8000, help="Port to bind (HTTP transport only)")
+@click.option(
+    "--port",
+    type=int,
+    default=_default_port,
+    help="Port to bind (HTTP transport only; defaults to $PORT or 8000)",
+)
 @click.option(
     "--env-file",
     type=click.Path(exists=True, path_type=Path),


### PR DESCRIPTION
- Replace invalid alpaca-mcp-server serve CMD with streamable-http on 0.0.0.0
- Default HTTP port from PORT env (Render) when --port is omitted
- Accept legacy leading serve argv for old Docker/Helm configs
- Align Helm chart args with the real CLI

Made-with: Cursor