### PR TITLE
feat: add news toolset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This MCP server auto-generates tools from bundled OpenAPI specs (`src/alpaca_mcp
 
 The test suite has three layers:
 - `tests/test_integrity.py` — Spec ↔ toolset ↔ names consistency (no network)
-- `tests/test_server_construction.py` — Server builds correctly, exposes 61 tools (no network)
+- `tests/test_server_construction.py` — Server builds correctly, exposes 62 tools (no network)
 - `tests/test_paper_integration.py` — Real API calls against Alpaca paper (needs credentials)
 
 CI is defined in `.github/workflows/ci.yml` with two jobs: `test-core` (runs on every PR) and `test-integration` (runs when `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` secrets are available).

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Available toolsets:
 - **Options Trading** — Search contracts by expiration/strike/type. Place single-leg or multi-leg strategies. Get latest quotes, Greeks, and IV.
 - **Crypto Trading** — Market, limit, and stop-limit orders with GTC/IOC. Quantity or notional-based.
 - **Position Management** — View, close, or liquidate positions. Exercise option contracts.
-- **News** — Benzinga-sourced news articles filterable by ticker and date range.
+- **News** — News articles filterable by ticker and date range.
 - **Market Status** — Market open/close times, calendar, corporate actions.
 - **Watchlists** — Create, update, and manage watchlists.
 - **Asset Search** — Query details for stocks, ETFs, crypto, and options with filtering.
@@ -475,7 +475,7 @@ Available toolsets:
 
 **News**
 
-- `get_news` — News articles for stocks and crypto, sourced from Benzinga
+- `get_news` — News articles for stocks and crypto
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Available toolsets:
 | `crypto-data`       | Crypto bars, quotes, trades, snapshots, orderbooks            |
 | `options-data`      | Option bars, quotes, trades, snapshots, chain, exchange codes |
 | `corporate-actions` | Corporate action announcements                                |
+| `news`              | News articles for stocks and crypto                           |
 
 
 ## Features
@@ -292,6 +293,7 @@ Available toolsets:
 - **Options Trading** — Search contracts by expiration/strike/type. Place single-leg or multi-leg strategies. Get latest quotes, Greeks, and IV.
 - **Crypto Trading** — Market, limit, and stop-limit orders with GTC/IOC. Quantity or notional-based.
 - **Position Management** — View, close, or liquidate positions. Exercise option contracts.
+- **News** — Benzinga-sourced news articles filterable by ticker and date range.
 - **Market Status** — Market open/close times, calendar, corporate actions.
 - **Watchlists** — Create, update, and manage watchlists.
 - **Asset Search** — Query details for stocks, ETFs, crypto, and options with filtering.
@@ -470,6 +472,10 @@ Available toolsets:
 **Corporate Actions**
 
 - `get_corporate_actions` — Corporate action announcements from market data
+
+**News**
+
+- `get_news` — News articles for stocks and crypto, sourced from Benzinga
 
 ## Testing
 

--- a/src/alpaca_mcp_server/names.py
+++ b/src/alpaca_mcp_server/names.py
@@ -363,7 +363,7 @@ TOOLS: dict[str, ToolOverride] = {
     "News": ToolOverride(
         name="get_news",
         description=(
-            "Retrieves news articles for stocks and crypto, sourced from Benzinga. "
+            "Retrieves news articles for stocks and crypto. "
             "Filter by symbols, date range, and sort order. "
             "Returns headlines, summaries, URLs, and associated ticker symbols."
         ),

--- a/src/alpaca_mcp_server/names.py
+++ b/src/alpaca_mcp_server/names.py
@@ -358,6 +358,16 @@ TOOLS: dict[str, ToolOverride] = {
         name="get_corporate_actions",
         description="Retrieves and formats corporate action announcements.",
     ),
+
+    # --- News ---
+    "News": ToolOverride(
+        name="get_news",
+        description=(
+            "Retrieves news articles for stocks and crypto, sourced from Benzinga. "
+            "Filter by symbols, date range, and sort order. "
+            "Returns headlines, summaries, URLs, and associated ticker symbols."
+        ),
+    ),
 }
 
 # Derived lookups used by server.py

--- a/src/alpaca_mcp_server/toolsets.py
+++ b/src/alpaca_mcp_server/toolsets.py
@@ -107,6 +107,12 @@ TOOLSETS: dict[str, dict] = {
             "CorporateActions",
         },
     },
+    "news": {
+        "spec": "market-data",
+        "operations": {
+            "News",
+        },
+    },
 }
 
 OVERRIDE_OPERATION_IDS = {

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -90,6 +90,8 @@ EXPECTED_TOOLS = {
     "get_option_exchange_codes",
     # Corporate Actions (Market Data)
     "get_corporate_actions",
+    # News
+    "get_news",
     # Order Overrides
     "place_stock_order",
     "place_crypto_order",
@@ -107,9 +109,9 @@ async def _list_tools(env: dict | None = None) -> list:
 
 
 async def test_tool_count():
-    """Server must expose exactly 61 tools."""
+    """Server must expose exactly 62 tools."""
     tools = await _list_tools()
-    assert len(tools) == 61, f"Expected 61 tools, got {len(tools)}"
+    assert len(tools) == 62, f"Expected 62 tools, got {len(tools)}"
 
 
 async def test_tool_names_match():


### PR DESCRIPTION
The News endpoint (`GET /v1beta1/news`) is already in the bundled market-data OpenAPI spec but was never added to the toolset allowlist.  This PR adds it as a `news` toolset with a single `get_news` tool.

The endpoint is Benzinga-sourced and supports filtering by symbols, date range, and sort order.  No override is needed — `from_openapi()` handles it as a straightforward GET.

**Changes**

| File | What |
|---|---|
| `toolsets.py` | New `"news"` toolset with the `"News"` operationId |
| `names.py` | `ToolOverride` mapping `News` → `get_news` |
| `test_server_construction.py` | Expected tool count 61 → 62, `get_news` added to `EXPECTED_TOOLS` |
| `AGENTS.md` | Tool-count reference updated |
| `README.md` | Toolset table, Features list, and Available Tools section updated |

All integrity and server-construction tests pass locally.