### PR TITLE
feat: add advanced_instructions to place_stock_order (Elite Smart Router)

### DIFF
--- a/src/alpaca_mcp_server/overrides.py
+++ b/src/alpaca_mcp_server/overrides.py
@@ -84,6 +84,7 @@ def register_order_tools(
         take_profit_limit_price: Optional[str] = None,
         stop_loss_stop_price: Optional[str] = None,
         stop_loss_limit_price: Optional[str] = None,
+        advanced_instructions: Optional[dict] = None,
     ) -> dict:
         """Place a stock or ETF order.
 
@@ -111,6 +112,35 @@ def register_order_tools(
             take_profit_limit_price: Limit price for bracket take-profit leg.
             stop_loss_stop_price: Stop price for bracket stop-loss leg.
             stop_loss_limit_price: Limit price for bracket stop-loss leg.
+            advanced_instructions: Alpaca Elite Smart Router routing/algo
+                payload. Stocks-only (the Elite docs explicitly note options
+                and crypto reject the payload). Requires the account to be
+                on Elite Smart Router routing; non-Elite accounts will see
+                the field ignored or rejected by Alpaca's API. Shapes:
+                  DMA Gateway (direct routing):
+                    {"algorithm": "DMA",
+                     "destination": "NYSE"|"NASDAQ"|"ARCA",
+                     "display_qty": "<round lot, optional>"}
+                    Only with type="limit"|"market" and time_in_force="day";
+                    not compatible with opg/cls/gtc or stop orders.
+                  VWAP (Volume-Weighted Average Price):
+                    {"algorithm": "VWAP",
+                     "start_time": "<RFC3339, optional>",
+                     "end_time":   "<RFC3339, optional>",
+                     "max_percentage": "<0<x<1, optional>"}
+                    Does NOT participate in open/close auctions.
+                  TWAP (Time-Weighted Average Price):
+                    {"algorithm": "TWAP",
+                     "start_time": "<RFC3339, optional>",
+                     "end_time":   "<RFC3339, optional>",
+                     "max_percentage": "<0<x<1, optional>"}
+                    Does NOT participate in open/close auctions.
+                See https://docs.alpaca.markets/docs/alpaca-elite-smart-router
+                for the canonical reference. NOTE: PATCH /v2/orders/{id}
+                already documents `advanced_instructions` in the OpenAPI
+                spec (PatchOrderRequest), and `replace_order_by_id` exposes
+                it through auto-generation — this patch only addresses the
+                POST-side asymmetry.
         """
         if stop_loss_limit_price is not None and stop_loss_stop_price is None:
             return _error(
@@ -155,6 +185,8 @@ def register_order_tools(
             if stop_loss_limit_price is not None:
                 sl["limit_price"] = stop_loss_limit_price
             body["stop_loss"] = sl
+        if advanced_instructions is not None:
+            body["advanced_instructions"] = advanced_instructions
 
         return await _post_order(client, body)
 

--- a/src/alpaca_mcp_server/overrides.py
+++ b/src/alpaca_mcp_server/overrides.py
@@ -135,12 +135,11 @@ def register_order_tools(
                      "end_time":   "<RFC3339, optional>",
                      "max_percentage": "<0<x<1, optional>"}
                     Does NOT participate in open/close auctions.
-                See https://docs.alpaca.markets/docs/alpaca-elite-smart-router
-                for the canonical reference. NOTE: PATCH /v2/orders/{id}
-                already documents `advanced_instructions` in the OpenAPI
-                spec (PatchOrderRequest), and `replace_order_by_id` exposes
-                it through auto-generation — this patch only addresses the
-                POST-side asymmetry.
+                NOTE: PATCH /v2/orders/{id} already documents
+                `advanced_instructions` in the OpenAPI spec
+                (PatchOrderRequest), and `replace_order_by_id` exposes
+                it through auto-generation — this patch only addresses
+                the POST-side asymmetry.
         """
         if stop_loss_limit_price is not None and stop_loss_stop_price is None:
             return _error(


### PR DESCRIPTION
## Summary

Threads Alpaca Elite Smart Router routing through `place_stock_order` so DMA / VWAP / TWAP can be specified when placing stock orders. Closes the POST-side asymmetry that the hand-crafted override created.

## The asymmetry this fixes

Alpaca's upstream `trading-api.json` documents `advanced_instructions` on **PATCH** /v2/orders/{order_id} (`PatchOrderRequest.properties.advanced_instructions` → `\$ref AdvancedInstructions`) but **not on POST** /v2/orders. Because `postOrder` is in `OVERRIDE_OPERATION_IDS` (replaced by the hand-crafted `place_stock_order` in `overrides.py`), the auto-generator can't pick up the missing field — even if Alpaca later adds it to the POST schema, the override would still need updating.

Meanwhile, `patchOrderByOrderId` is auto-generated and inherits the spec faithfully, so `replace_order_by_id` already exposes `advanced_instructions` natively. Users can PATCH-replace routing on an open order but couldn't place a new one with the routing attached — until this PR.

## Patch shape

One file changed (`src/alpaca_mcp_server/overrides.py`), 32 insertions:

1. New optional parameter `advanced_instructions: Optional[dict] = None` on `place_stock_order` (last arg, after the bracket-leg params)
2. Body pass-through: `if advanced_instructions is not None: body[\"advanced_instructions\"] = advanced_instructions`
3. Docstring covers the three documented algorithm shapes (DMA / VWAP / TWAP) per the [Elite Smart Router docs page](https://docs.alpaca.markets/docs/alpaca-elite-smart-router)

Stocks-only by design — per the Elite docs, options and crypto reject the payload. `place_crypto_order` and `place_option_order` intentionally unchanged.

## Testing

Tested against a paper account (`PA3PKN9DFCE5`) using the patched server installed via pip from a private downstream fork:

```python
place_stock_order(
    symbol=\"SPY\", side=\"buy\", qty=\"1\", type=\"limit\",
    time_in_force=\"day\", limit_price=\"600.00\",
    client_order_id=\"smoke-1\",
    advanced_instructions={\"algorithm\": \"DMA\", \"destination\": \"ARCA\"},
)
```

Response: HTTP 200, `advanced_instructions` echoes in the order payload (`{\"algorithm\": \"DMA\", \"destination\": \"ARCA\"}`), order accepts and cancels cleanly.

Runtime constraints noted during testing (not enforced in this tool, since they're Alpaca-side):
- `display_qty` must be in round-lot increments; fractional values return code 42210000
- DMA only with `type=\"limit\"|\"market\"` and `time_in_force=\"day\"`; not compatible with opg/cls/gtc or stop orders (per the Elite docs)
- VWAP / TWAP don't participate in open/close auctions

## Out of scope

- `replace_order_by_id` PATCH support — already works via auto-gen (the spec covers it)
- Midpoint Peg / Pegged / PVOL — Alpaca documents these as \"Coming soon\" on the Elite Smart Router page

## Origin

This patch landed downstream first (private fork — \`CannonWest/alpaca-mcp-server@2.0.1-cground.1\`, internal install for a personal trading workspace). Submitting back upstream so the gap is closed for everyone using the official server.