### PR TITLE
fix(railway): use SSE transport + /sse healthcheck for Railway deploys

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "startCommand": "alpaca-mcp-server --transport sse --host 0.0.0.0",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5,
+    "healthcheckPath": "/sse"
+  }
+}


### PR DESCRIPTION
## Summary
- add railway.json for Railway Config-as-Code deployment
- set start command to use SSE transport on 0.0.0.0
- set healthcheck path to /sse

## Why
Railway healthchecks against /health fail for this server because no /health route is exposed in HTTP transports. SSE mode provides a GET-friendly /sse endpoint that returns 200.

## Scope
- deployment config only (railway.json)
- no application code changes