### PR TITLE
fix: accept JSON-stringified legs in place_option_order

### DIFF
--- a/src/alpaca_mcp_server/overrides.py
+++ b/src/alpaca_mcp_server/overrides.py
@@ -8,7 +8,8 @@ tools with curated parameters per asset class.
 
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import Optional, Union
 
 import httpx
 from fastmcp import FastMCP
@@ -265,7 +266,7 @@ def register_order_tools(
         limit_price: Optional[str] = None,
         client_order_id: Optional[str] = None,
         order_class: Optional[str] = None,
-        legs: Optional[list[dict]] = None,
+        legs: Optional[Union[list[dict], str]] = None,
     ) -> dict:
         """Place an options order (single-leg or multi-leg).
 
@@ -301,8 +302,25 @@ def register_order_tools(
             legs: List of leg dicts for multi-leg orders (max 4). Each leg
                   requires "symbol" and "ratio_qty" (string). Optional
                   per-leg fields: "side" ("buy" or "sell") and
-                  "position_intent".
+                  "position_intent". A JSON-encoded string of the same
+                  array is also accepted (some MCP clients serialise
+                  array parameters as strings).
         """
+        # Some MCP clients serialise the legs array as a JSON string
+        # (schema for Optional[list[dict]] carries no "type": "array").
+        # Accept both and normalise to a list before validation below.
+        if isinstance(legs, str):
+            try:
+                legs = json.loads(legs)
+            except json.JSONDecodeError:
+                return _error(
+                    "legs must be a JSON array of leg objects, e.g. "
+                    '[{"symbol": "...", "ratio_qty": "1", "side": "sell", '
+                    '"position_intent": "sell_to_open"}]'
+                )
+            if not isinstance(legs, list):
+                return _error("legs must be a JSON array of leg objects")
+
         is_multi_leg = legs is not None or order_class == "mleg"
 
         if is_multi_leg and legs is None:

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -8,6 +8,7 @@ parsing failures, and toolset/names misconfiguration.
 
 from __future__ import annotations
 
+import json
 import os
 from unittest.mock import patch
 
@@ -156,3 +157,72 @@ async def test_toolset_filtering():
     assert "get_account_info" in names
     assert "place_stock_order" not in names
     assert "get_stock_bars" not in names
+
+
+_TEST_LEGS = [
+    {
+        "symbol": "SPY260717P00700000",
+        "ratio_qty": "1",
+        "side": "sell",
+        "position_intent": "sell_to_open",
+    },
+    {
+        "symbol": "SPY260717P00690000",
+        "ratio_qty": "1",
+        "side": "buy",
+        "position_intent": "buy_to_open",
+    },
+]
+
+
+@pytest.mark.parametrize("legs_arg", [_TEST_LEGS, json.dumps(_TEST_LEGS)])
+async def test_place_option_order_accepts_list_and_stringified_legs(legs_arg):
+    """Regression: multi-leg orders must work whether `legs` arrives as a
+    list or as a JSON-encoded string.
+
+    The generated JSON schema for ``Optional[list[dict]]`` carries no
+    explicit ``"type": "array"``, so some MCP clients (Claude Desktop
+    among them) serialise the legs array as a string. Validation then
+    rejected the call before the handler ran, making multi-leg orders
+    unplaceable from those clients.
+    """
+    captured: dict = {}
+
+    async def _fake_post_order(client, body):
+        captured.update(body)
+        return {"status": "accepted"}
+
+    with patch.dict(os.environ, DUMMY_ENV, clear=False):
+        server = build_server()
+
+    with patch(
+        "alpaca_mcp_server.overrides._post_order", new=_fake_post_order
+    ):
+        async with Client(transport=server) as c:
+            await c.call_tool(
+                "place_option_order",
+                {
+                    "qty": "1",
+                    "type": "limit",
+                    "limit_price": "-2.50",
+                    "legs": legs_arg,
+                },
+            )
+
+    assert captured.get("order_class") == "mleg"
+    assert captured.get("legs") == _TEST_LEGS
+
+
+async def test_place_option_order_rejects_malformed_legs_string():
+    """A legs string that is not valid JSON must return a structured
+    error rather than reach the API."""
+    with patch.dict(os.environ, DUMMY_ENV, clear=False):
+        server = build_server()
+
+    async with Client(transport=server) as c:
+        result = await c.call_tool(
+            "place_option_order",
+            {"qty": "1", "legs": "not-json"},
+        )
+
+    assert "legs must be a JSON array" in str(result)


### PR DESCRIPTION
## Problem

Multi-leg option orders via `place_option_order` fail before reaching the API when the MCP client serialises the `legs` array as a JSON string. The call dies with a pydantic validation error (`legs` must be a list, got str), so the handler never runs.

This is not hypothetical: Claude Desktop does exactly this. The generated JSON schema for `Optional[list[dict]]` carries no explicit `"type": "array"` (it renders as a nullable anyOf), and clients that cannot determine the parameter type fall back to sending the value as a string. From such clients, **every** multi-leg order is unplaceable — single-leg orders work fine, which makes this easy to miss in testing.

Observed in the wild: three otherwise-valid SPY credit-spread orders rejected client-side over two days, all with:

```
validation error for place_option_order: legs — Input should be a valid list [type=list_type, input_value='[{"symbol": ...}]', input_type=str]
```

## Fix

- Widen the signature to `legs: Optional[Union[list[dict], str]]` so the stringified form survives validation (a parse inside the handler alone would be dead code — validation rejects the call before dispatch).
- Parse the string with `json.loads` at the top of the handler, returning the existing structured `_error` shape for malformed input.
- Document the accepted string form in the `legs` docstring so it surfaces in the tool schema.

## Tests

Added to the no-network construction layer (`tests/test_server_construction.py`):

- `test_place_option_order_accepts_list_and_stringified_legs` — parametrised over a real list and its `json.dumps` form; asserts the posted body contains a proper list and `order_class: "mleg"` in both cases.
- `test_place_option_order_rejects_malformed_legs_string` — non-JSON string returns the structured error, nothing reaches the API.

`pytest tests/test_server_construction.py tests/test_integrity.py` — 15 passed.

Also verified end-to-end against a live paper account: a stringified-legs mleg order that previously failed validation is accepted by Alpaca with both legs registered correctly.
