### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/.well-known/mcp/manifest.json
+++ b/.well-known/mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "GitHub MCP Registry Manifest",
   "_location": "/.well-known/mcp/manifest.json",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "schema_version": "0.2.0",
   "manifest_version": "0.3",
   "name": "alpaca-mcp-server",

--- a/charts/alpaca-mcp-server/Chart.yaml
+++ b/charts/alpaca-mcp-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.0"
+appVersion: "2.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "alpaca-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "Alpaca Trading API integration for Model Context Protocol (MCP)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/alpacahq/alpaca-mcp-server",
     "source": "github"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "alpaca-mcp-server",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "transport": {
         "type": "stdio"
       },

--- a/server.yaml
+++ b/server.yaml
@@ -82,7 +82,7 @@ config:
 metadata:
   license: MIT
   maintainer: Alpaca <https://alpaca.markets/contact>
-  version: "2.1.0"
+  version: "2.1.1"
 
   docker:
     transport: stdio

--- a/src/alpaca_mcp_server/__init__.py
+++ b/src/alpaca_mcp_server/__init__.py
@@ -12,7 +12,7 @@ Key Features:
 - Corporate actions and market calendar
 """
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __author__ = "Alpaca"
 __license__ = "MIT"
 __description__ = "Alpaca Trading API integration for Model Context Protocol (MCP)"


### PR DESCRIPTION
Bump version to 2.1.1 across all 6 files for PyPI release after locates sync.

Made with [Cursor](https://cursor.com)