### PR TITLE
Fix README setup anchors for mcp-server website backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,22 +115,15 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (Mac) or 
 
 ### Claude Mobile
 
-Alpaca does not provide a hosted remote MCP server. To use the MCP server on the Claude mobile app, host it remotely (for example with Docker and a cloud provider), then add it as a custom connector in Claude. The connector syncs to the mobile app once connected on the web.
+Alpaca does not provide a hosted remote MCP server. To use the MCP server on the Claude mobile app, host it remotely on a cloud provider, then add it as a custom connector in Claude. The connector syncs to the mobile app once connected on the web.
 
-1. Build and deploy the server with HTTP transport (see [Docker](#docker) below).
-2. In Claude, open **Search and tools** → **Manage connectors** → **Add custom connector**.
-3. Enter your deployed MCP URL (for example `https://your-domain.com/mcp`).
-
-For a step-by-step walkthrough, see [How to Deploy Alpaca's MCP Server Remotely on Claude Mobile App](https://alpaca.markets/learn/how-to-deploy-alpaca-mcp-server-remotely-on-claude-mobile-app).
+For hosting, deployment, and connector setup, see [How to Deploy Alpaca's MCP Server Remotely on Claude Mobile App](https://alpaca.markets/learn/how-to-deploy-alpaca-mcp-server-remotely-on-claude-mobile-app).
 
 ### ChatGPT
 
-Alpaca does not provide a hosted remote MCP server. To use the MCP server in ChatGPT, host it remotely, then add it as a connector in ChatGPT.
+Alpaca does not provide a hosted remote MCP server. To use the MCP server in ChatGPT, host it remotely on a cloud provider, then add it as a connector.
 
-1. Build and deploy the server with HTTP transport (see [Docker](#docker) below).
-2. In ChatGPT, add a custom connector pointing at your deployed MCP URL.
-
-See [Connectors in ChatGPT](https://help.openai.com/en/articles/11487775-connectors-in-chatgpt) and the [Claude Mobile deployment guide](https://alpaca.markets/learn/how-to-deploy-alpaca-mcp-server-remotely-on-claude-mobile-app) for the same remote-hosting flow.
+See [Connectors in ChatGPT](https://help.openai.com/en/articles/11487775-connectors-in-chatgpt) and the [Claude Mobile deployment guide](https://alpaca.markets/learn/how-to-deploy-alpaca-mcp-server-remotely-on-claude-mobile-app) for hosting and setup steps.
 
 ### Cursor
 
@@ -227,7 +220,7 @@ cd alpaca-mcp-server
 docker build -t mcp/alpaca:latest .
 ```
 
-**Local stdio clients** — add to your MCP client config:
+Add to your MCP client config:
 
 ```json
 {
@@ -244,15 +237,6 @@ docker build -t mcp/alpaca:latest .
     }
   }
 }
-```
-
-**Remote connectors** (Claude Mobile, ChatGPT) — the image defaults to streamable HTTP on port 8000:
-
-```bash
-docker run --rm -p 8000:8000 \
-  -e ALPACA_API_KEY=your_alpaca_api_key \
-  -e ALPACA_SECRET_KEY=your_alpaca_secret_key \
-  mcp/alpaca:latest
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (Mac) or 
 }
 ```
 
+### Claude Mobile
+
+Alpaca does not provide a hosted remote MCP server. To use the MCP server on the Claude mobile app, host it remotely (for example with Docker and a cloud provider), then add it as a custom connector in Claude. The connector syncs to the mobile app once connected on the web.
+
+1. Build and deploy the server with HTTP transport (see [Docker](#docker) below).
+2. In Claude, open **Search and tools** → **Manage connectors** → **Add custom connector**.
+3. Enter your deployed MCP URL (for example `https://your-domain.com/mcp`).
+
+For a step-by-step walkthrough, see [How to Deploy Alpaca's MCP Server Remotely on Claude Mobile App](https://alpaca.markets/learn/how-to-deploy-alpaca-mcp-server-remotely-on-claude-mobile-app).
+
+### ChatGPT
+
+Alpaca does not provide a hosted remote MCP server. To use the MCP server in ChatGPT, host it remotely, then add it as a connector in ChatGPT.
+
+1. Build and deploy the server with HTTP transport (see [Docker](#docker) below).
+2. In ChatGPT, add a custom connector pointing at your deployed MCP URL.
+
+See [Connectors in ChatGPT](https://help.openai.com/en/articles/11487775-connectors-in-chatgpt) and the [Claude Mobile deployment guide](https://alpaca.markets/learn/how-to-deploy-alpaca-mcp-server-remotely-on-claude-mobile-app) for the same remote-hosting flow.
+
 ### Cursor
 
 Install from the [Cursor Directory](https://cursor.directory/mcp/alpaca) in a few clicks, or add to `~/.cursor/mcp.json`:
@@ -154,7 +173,7 @@ Create `.vscode/mcp.json` in your project root. See the [official docs](https://
 }
 ```
 
-**PyCharm**  
+### PyCharm
 
 See the [official guide](https://www.jetbrains.com/help/ai-assistant/configure-an-mcp-server.html).
 
@@ -169,7 +188,7 @@ See the [official guide](https://www.jetbrains.com/help/ai-assistant/configure-a
    ALPACA_SECRET_KEY=your_alpaca_secret_key
   ```
 
-**Claude Code**  
+### Claude Code
 
 ```bash
 claude mcp add alpaca --scope user --transport stdio uvx alpaca-mcp-server \
@@ -179,17 +198,16 @@ claude mcp add alpaca --scope user --transport stdio uvx alpaca-mcp-server \
 
 Verify with `/mcp` in the Claude Code CLI.
 
-**Gemini CLI**  
+### Antigravity CLI
 
-See the [Gemini CLI MCP docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md).
+See the [Antigravity MCP docs](https://antigravity.google/docs/mcp).
 
-Add to your `settings.json`:
+Add to `~/.gemini/antigravity-cli/mcp_config.json` (global) or `.agents/mcp_config.json` (workspace):
 
 ```json
 {
   "mcpServers": {
     "alpaca": {
-      "type": "stdio",
       "command": "uvx",
       "args": ["alpaca-mcp-server"],
       "env": {
@@ -201,7 +219,7 @@ Add to your `settings.json`:
 }
 ```
 
-**Docker**  
+### Docker
 
 ```bash
 git clone https://github.com/alpacahq/alpaca-mcp-server.git
@@ -209,7 +227,7 @@ cd alpaca-mcp-server
 docker build -t mcp/alpaca:latest .
 ```
 
-Add to your MCP client config:
+**Local stdio clients** — add to your MCP client config:
 
 ```json
 {
@@ -226,6 +244,15 @@ Add to your MCP client config:
     }
   }
 }
+```
+
+**Remote connectors** (Claude Mobile, ChatGPT) — the image defaults to streamable HTTP on port 8000:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e ALPACA_API_KEY=your_alpaca_api_key \
+  -e ALPACA_SECRET_KEY=your_alpaca_secret_key \
+  mcp/alpaca:latest
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary
- Convert all MCP client setup sections to `###` headings so GitHub generates stable anchors for [alpaca.markets/mcp-server](https://alpaca.markets/mcp-server) deep links
- Add missing **Claude Mobile** and **ChatGPT** remote-hosting setup sections
- Replace **Gemini CLI** with **Antigravity CLI** and link to the [Antigravity MCP docs](https://antigravity.google/docs/mcp)
- Expand the **Docker** section with separate local stdio and remote connector examples

## Anchor mapping (for website PR)
| Card | New anchor |
|---|---|
| Claude Desktop | `#claude-desktop` |
| Claude Mobile | `#claude-mobile` |
| ChatGPT | `#chatgpt` |
| Cursor | `#cursor` |
| Visual Studio Code | `#vs-code` |
| PyCharm | `#pycharm` |
| Claude Code | `#claude-code` |
| Antigravity CLI | `#antigravity-cli` |

## Test plan
- [ ] Verify each anchor scrolls to the correct section on the rendered README (e.g. `#claude-desktop`, `#antigravity-cli`)
- [ ] Update `alpacahq/website` `v2/mcp-server.html` hrefs to match after this merges


Made with [Cursor](https://cursor.com)