### PR TITLE
feat: optional independent pre-trade review middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,10 +628,21 @@ close positions) on an independent, signed pre-trade verdict from
 [invinoveritas](https://api.babyblueviper.com) before it executes -- an automated second opinion
 for the "review all actions proposed by the LLM carefully" guidance above, not a replacement for it.
 
-Not a rule engine: a judgment call on the specific order (symbol, side, size, type), issued by a
-party structurally separate from the agent placing it. Every verdict is independently
-recomputable via `/verify-proof` (free, no auth) -- nothing to trust on our word. Fails open on
-any network/timeout/malformed-response issue, so a `/review`-side problem never blocks trading.
+Not a rule engine: a judgment call on the specific order, issued by a party structurally
+separate from the agent placing it. Every verdict is independently recomputable via
+`/verify-proof` (free, no auth) -- nothing to trust on our word. Fails open on any
+network/timeout/malformed-response issue, so a `/review`-side problem never blocks trading; every
+destructive call's result carries an `invinoveritas_review` marker in `meta` either way
+(`"unavailable"` on fail-open, or the actual verdict), so it's always visible which calls were
+reviewed and which weren't -- never silent either way.
+
+**What's sent externally:** the complete argument dictionary of the destructive call being
+reviewed -- for `place_stock_order` that's `symbol`, `side`, `qty`/`notional`, `type`,
+`time_in_force`, any limit/stop/trail prices, `client_order_id`, `order_class`, and bracket/
+multi-leg fields if present; other destructive tools send their own full argument set the same
+way. Sent over HTTPS to `api.babyblueviper.com/review` with your `IVV_API_KEY` as bearer auth.
+No account credentials, Alpaca API keys, or account/portfolio state are ever sent -- only the
+arguments of the specific call under review.
 
 ```python
 from alpaca_mcp_server.invinoveritas_review import InvinoveritasReviewMiddleware

--- a/README.md
+++ b/README.md
@@ -620,6 +620,28 @@ This server can place real trades and access your portfolio. Treat your API keys
 
 **HTTP Transport Security**: When using HTTP transport, the server defaults to localhost (127.0.0.1:8000) for security. For remote access, you can bind to all interfaces with `--host 0.0.0.0`, use SSH tunneling (`ssh -L 8000:localhost:8000 user@server`), or set up a reverse proxy with authentication for secure access.
 
+## Optional: Independent Pre-Trade Review
+
+`InvinoveritasReviewMiddleware` (`src/alpaca_mcp_server/invinoveritas_review.py`) is an opt-in
+middleware that gates any tool call marked `destructiveHint: true` (place/cancel/replace orders,
+close positions) on an independent, signed pre-trade verdict from
+[invinoveritas](https://api.babyblueviper.com) before it executes -- an automated second opinion
+for the "review all actions proposed by the LLM carefully" guidance above, not a replacement for it.
+
+Not a rule engine: a judgment call on the specific order (symbol, side, size, type), issued by a
+party structurally separate from the agent placing it. Every verdict is independently
+recomputable via `/verify-proof` (free, no auth) -- nothing to trust on our word. Fails open on
+any network/timeout/malformed-response issue, so a `/review`-side problem never blocks trading.
+
+```python
+from alpaca_mcp_server.invinoveritas_review import InvinoveritasReviewMiddleware
+
+main.add_middleware(InvinoveritasReviewMiddleware(block_on_reject=True))  # or False for advisory-only
+```
+
+Requires `IVV_API_KEY` (free registration: `POST https://api.babyblueviper.com/register`).
+Tests: `pytest tests/test_invinoveritas_review.py -v` (no live API key needed, real HTTP mocking).
+
 ## Support
 
 For issues or questions, please contact us at [support@alpaca.markets](mailto:support@alpaca.markets).

--- a/src/alpaca_mcp_server/invinoveritas_review.py
+++ b/src/alpaca_mcp_server/invinoveritas_review.py
@@ -16,13 +16,24 @@ Design mirrors the same discipline as invinoveritas's other integrations
   - FAIL-OPEN on any /review-side problem (network error, timeout, malformed
     response, missing key) -- the order proceeds as if ungated rather than
     silently hanging or blocking the gateway on our service having a bad
-    moment. `_alpaca_mcp_security` metadata on the tool result carries an
-    `invinoveritas_review: "unavailable"` marker so this is visible, not
-    silent.
+    moment. Every destructive call's result carries an `invinoveritas_review`
+    marker in `meta` regardless of outcome ("unavailable" on fail-open,
+    "approve"/"approve_with_concerns" on a passed review) -- so a client or
+    audit consumer can always tell an unreviewed destructive call apart from
+    a reviewed one, not just infer it from the absence of an error.
   - GATES on a real `reject` verdict by default (block_on_reject=True in the
     constructor). Pass block_on_reject=False for an advisory/observe-only
-    rollout that never blocks, only annotates.
+    rollout that never blocks, only annotates (the marker on `meta` still
+    reports "reject" in that mode, it just doesn't raise).
   - Never overrides an approve/approve_with_concerns verdict.
+
+Data sent externally: on every destructive call, the full tool argument
+dictionary (e.g. for place_stock_order -- symbol, side, qty/notional, type,
+time_in_force, limit/stop/trail prices, client_order_id, order_class, and any
+bracket/multi-leg fields present) is sent to the invinoveritas /review
+endpoint as part of the review artifact, over HTTPS with your IVV_API_KEY as
+bearer auth. No account credentials, API keys, or account/portfolio state are
+sent -- only the arguments of the specific call being reviewed.
 
 Usage (opt-in, disabled unless explicitly wired -- see README):
 
@@ -85,6 +96,7 @@ class InvinoveritasReviewMiddleware(Middleware):
             return await call_next(context)
 
         verdict = await self._review(tool_name, context.message.arguments)
+        marker = verdict.get("verdict") if verdict is not None else "unavailable"
 
         if verdict is not None and verdict.get("verdict") == "reject" and self._block_on_reject:
             logger.warning(
@@ -99,7 +111,13 @@ class InvinoveritasReviewMiddleware(Middleware):
                 f"POST {self._base_url}/verify-proof"
             )
 
-        return await call_next(context)
+        result = await call_next(context)
+        return ToolResult(
+            content=result.content,
+            structured_content=result.structured_content,
+            meta={**(result.meta or {}), "invinoveritas_review": marker},
+            is_error=result.is_error,
+        )
 
     # ---- internals ----
 

--- a/src/alpaca_mcp_server/invinoveritas_review.py
+++ b/src/alpaca_mcp_server/invinoveritas_review.py
@@ -1,0 +1,153 @@
+"""
+Optional pre-trade gate: an independent invinoveritas /review verdict on
+destructive tool calls (place_stock_order, place_crypto_order,
+place_option_order, cancel_order_by_id, cancel_all_orders, close_position,
+close_all_positions, replace_order_by_id, ...).
+
+Not a rule engine — a signed, independently-recomputable judgment call issued
+by a party structurally separate from the agent placing the order. Gates on
+the same MCP `destructiveHint` annotation this server already uses for its own
+tool metadata (see server.tool(annotations=...) calls in overrides.py), so it
+composes with any current or future destructive tool without a hardcoded
+name list.
+
+Design mirrors the same discipline as invinoveritas's other integrations
+(AutoGen GovernedWorkbench, mcp-context-forge InvinoveritasReviewPlugin):
+  - FAIL-OPEN on any /review-side problem (network error, timeout, malformed
+    response, missing key) -- the order proceeds as if ungated rather than
+    silently hanging or blocking the gateway on our service having a bad
+    moment. `_alpaca_mcp_security` metadata on the tool result carries an
+    `invinoveritas_review: "unavailable"` marker so this is visible, not
+    silent.
+  - GATES on a real `reject` verdict by default (block_on_reject=True in the
+    constructor). Pass block_on_reject=False for an advisory/observe-only
+    rollout that never blocks, only annotates.
+  - Never overrides an approve/approve_with_concerns verdict.
+
+Usage (opt-in, disabled unless explicitly wired -- see README):
+
+    from .invinoveritas_review import InvinoveritasReviewMiddleware
+    main.add_middleware(InvinoveritasReviewMiddleware())
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Optional
+
+import httpx
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.babyblueviper.com"
+DEFAULT_TIMEOUT_S = 15.0
+_VALID_VERDICTS = ("approve", "approve_with_concerns", "reject")
+
+
+class InvinoveritasReviewMiddleware(Middleware):
+    """Gates destructive tool calls on an independent invinoveritas /review verdict.
+
+    Register free, instant, no payment: POST https://api.babyblueviper.com/register
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        block_on_reject: bool = True,
+        sign: bool = False,
+        artifact_type: str = "financial_transaction",
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._api_key = api_key or os.environ.get("IVV_API_KEY")
+        self._base_url = base_url
+        self._block_on_reject = block_on_reject
+        self._sign = sign
+        self._artifact_type = artifact_type
+        self._timeout_s = timeout_s
+        if not self._api_key:
+            logger.warning(
+                "InvinoveritasReviewMiddleware: no IVV_API_KEY set (constructor arg or env "
+                "var) -- every destructive tool call will proceed UNGATED. Register free at "
+                "%s/register",
+                self._base_url,
+            )
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next) -> ToolResult:
+        tool_name = context.message.name
+
+        if not await self._is_destructive(context, tool_name):
+            return await call_next(context)
+
+        verdict = await self._review(tool_name, context.message.arguments)
+
+        if verdict is not None and verdict.get("verdict") == "reject" and self._block_on_reject:
+            logger.warning(
+                "InvinoveritasReviewMiddleware BLOCK %r (confidence=%s)",
+                tool_name, verdict.get("confidence"),
+            )
+            raise ToolError(
+                f"Tool call to {tool_name!r} BLOCKED by an independent invinoveritas /review "
+                f"verdict (reject, confidence={verdict.get('confidence')}). "
+                f"{verdict.get('summary', '')} "
+                f"Verify this verdict yourself, no trust required: "
+                f"POST {self._base_url}/verify-proof"
+            )
+
+        return await call_next(context)
+
+    # ---- internals ----
+
+    async def _is_destructive(self, context: MiddlewareContext, tool_name: str) -> bool:
+        fastmcp_ctx = context.fastmcp_context
+        if fastmcp_ctx is None:
+            return False
+        try:
+            tool = await fastmcp_ctx.fastmcp.get_tool(tool_name)
+        except Exception:  # noqa: BLE001 -- unknown tool, nothing to gate
+            return False
+        return bool(tool.annotations and tool.annotations.destructiveHint)
+
+    async def _review(self, tool_name: str, arguments: dict[str, Any] | None) -> Optional[dict[str, Any]]:
+        """Returns the /review response dict, or None on any failure/misconfiguration
+        (fail-open -- the caller treats None exactly like an approve)."""
+        if not self._api_key:
+            return None
+
+        artifact = json.dumps({"tool_name": tool_name, "arguments": dict(arguments or {})}, default=str)
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout_s) as client:
+                resp = await client.post(
+                    f"{self._base_url}/review",
+                    headers={"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"},
+                    json={
+                        "artifact": artifact,
+                        "artifact_type": self._artifact_type,
+                        "context": f"Alpaca MCP tool call: {tool_name}",
+                        "sign": self._sign,
+                    },
+                )
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("verdict") not in _VALID_VERDICTS:
+                logger.warning(
+                    "InvinoveritasReviewMiddleware: malformed /review response for %r, failing open: %r",
+                    tool_name, data,
+                )
+                return None
+            logger.info(
+                "InvinoveritasReviewMiddleware: %r -> %s (confidence=%s)",
+                tool_name, data.get("verdict"), data.get("confidence"),
+            )
+            return data
+        except Exception as e:  # noqa: BLE001 -- fail-open on ANY error, by design
+            logger.warning(
+                "InvinoveritasReviewMiddleware: /review call failed for %r (%s), failing open",
+                tool_name, e,
+            )
+            return None

--- a/tests/test_invinoveritas_review.py
+++ b/tests/test_invinoveritas_review.py
@@ -69,6 +69,7 @@ async def test_readonly_tool_never_reviewed(monkeypatch):
     async with Client(server) as client:
         result = await client.call_tool("get_account", {})
         assert result.data["cash"] == "1000.00"
+        assert result.meta is None or "invinoveritas_review" not in result.meta
     assert called["n"] == 0
 
 
@@ -83,6 +84,7 @@ async def test_approve_passes_through(monkeypatch):
     async with Client(server) as client:
         result = await client.call_tool("place_stock_order", {"symbol": "SPY", "side": "buy", "qty": "1"})
         assert result.data["status"] == "filled"
+        assert result.meta["invinoveritas_review"] == "approve"
 
 
 @pytest.mark.asyncio
@@ -96,6 +98,7 @@ async def test_advisory_mode_never_blocks(monkeypatch):
     async with Client(server) as client:
         result = await client.call_tool("place_stock_order", {"symbol": "TSLA", "side": "sell", "qty": "5"})
         assert result.data["status"] == "filled"
+        assert result.meta["invinoveritas_review"] == "reject"
 
 
 @pytest.mark.asyncio
@@ -109,6 +112,7 @@ async def test_fails_open_on_network_error(monkeypatch):
     async with Client(server) as client:
         result = await client.call_tool("place_stock_order", {"symbol": "MSFT", "side": "buy", "qty": "1"})
         assert result.data["status"] == "filled"
+        assert result.meta["invinoveritas_review"] == "unavailable"
 
 
 @pytest.mark.asyncio
@@ -126,4 +130,5 @@ async def test_no_api_key_skips_review_entirely(monkeypatch):
     async with Client(server) as client:
         result = await client.call_tool("place_stock_order", {"symbol": "GME", "side": "buy", "qty": "1"})
         assert result.data["status"] == "filled"
+        assert result.meta["invinoveritas_review"] == "unavailable"
     assert called["n"] == 0

--- a/tests/test_invinoveritas_review.py
+++ b/tests/test_invinoveritas_review.py
@@ -1,0 +1,129 @@
+"""Tests for InvinoveritasReviewMiddleware -- no network calls, real HTTP mocking
+via httpx.MockTransport, real FastMCP server + tool registration (not mocked).
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+
+from alpaca_mcp_server.invinoveritas_review import InvinoveritasReviewMiddleware
+
+
+def _build_server(middleware: InvinoveritasReviewMiddleware) -> FastMCP:
+    server = FastMCP("test-alpaca")
+    server.add_middleware(middleware)
+
+    @server.tool(annotations={"destructiveHint": True, "readOnlyHint": False})
+    async def place_stock_order(symbol: str, side: str, qty: str) -> dict:
+        return {"status": "filled", "symbol": symbol, "side": side, "qty": qty}
+
+    @server.tool(annotations={"readOnlyHint": True, "destructiveHint": False})
+    async def get_account() -> dict:
+        return {"cash": "1000.00"}
+
+    return server
+
+
+def _patch_httpx(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+
+    class PatchedClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", PatchedClient)
+
+
+@pytest.mark.asyncio
+async def test_reject_blocks_destructive_tool(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["artifact_type"] == "financial_transaction"
+        assert json.loads(body["artifact"])["tool_name"] == "place_stock_order"
+        return httpx.Response(200, json={"verdict": "reject", "confidence": 0.9, "summary": "Notional exceeds daily risk limit."})
+
+    _patch_httpx(monkeypatch, handler)
+    server = _build_server(InvinoveritasReviewMiddleware(api_key="test_key"))
+
+    async with Client(server) as client:
+        with pytest.raises(ToolError, match="BLOCKED"):
+            await client.call_tool("place_stock_order", {"symbol": "AAPL", "side": "buy", "qty": "10000"})
+
+
+@pytest.mark.asyncio
+async def test_readonly_tool_never_reviewed(monkeypatch):
+    called = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["n"] += 1
+        return httpx.Response(200, json={"verdict": "reject"})
+
+    _patch_httpx(monkeypatch, handler)
+    server = _build_server(InvinoveritasReviewMiddleware(api_key="test_key"))
+
+    async with Client(server) as client:
+        result = await client.call_tool("get_account", {})
+        assert result.data["cash"] == "1000.00"
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_approve_passes_through(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"verdict": "approve", "confidence": 0.98})
+
+    _patch_httpx(monkeypatch, handler)
+    server = _build_server(InvinoveritasReviewMiddleware(api_key="test_key"))
+
+    async with Client(server) as client:
+        result = await client.call_tool("place_stock_order", {"symbol": "SPY", "side": "buy", "qty": "1"})
+        assert result.data["status"] == "filled"
+
+
+@pytest.mark.asyncio
+async def test_advisory_mode_never_blocks(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"verdict": "reject", "confidence": 0.9})
+
+    _patch_httpx(monkeypatch, handler)
+    server = _build_server(InvinoveritasReviewMiddleware(api_key="test_key", block_on_reject=False))
+
+    async with Client(server) as client:
+        result = await client.call_tool("place_stock_order", {"symbol": "TSLA", "side": "sell", "qty": "5"})
+        assert result.data["status"] == "filled"
+
+
+@pytest.mark.asyncio
+async def test_fails_open_on_network_error(monkeypatch):
+    def raise_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("simulated timeout")
+
+    _patch_httpx(monkeypatch, raise_handler)
+    server = _build_server(InvinoveritasReviewMiddleware(api_key="test_key"))
+
+    async with Client(server) as client:
+        result = await client.call_tool("place_stock_order", {"symbol": "MSFT", "side": "buy", "qty": "1"})
+        assert result.data["status"] == "filled"
+
+
+@pytest.mark.asyncio
+async def test_no_api_key_skips_review_entirely(monkeypatch):
+    called = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["n"] += 1
+        return httpx.Response(200, json={"verdict": "reject"})
+
+    _patch_httpx(monkeypatch, handler)
+    monkeypatch.delenv("IVV_API_KEY", raising=False)
+    server = _build_server(InvinoveritasReviewMiddleware())
+
+    async with Client(server) as client:
+        result = await client.call_tool("place_stock_order", {"symbol": "GME", "side": "buy", "qty": "1"})
+        assert result.data["status"] == "filled"
+    assert called["n"] == 0


### PR DESCRIPTION
Real find while looking at the trust-boundary work already in this repo: `security.py`'s output-side guard is genuinely well-designed (server-authored envelope, risk classification per tool), and the `destructiveHint` annotations already mark exactly the tools that place/modify/cancel real orders. There's no equivalent gate on the *input* side — before a destructive call executes, not after its output comes back.

## What this adds

`InvinoveritasReviewMiddleware` — an opt-in `FastMCP` middleware gating any `destructiveHint: true` tool call on an independent, signed pre-trade verdict from [invinoveritas](https://api.babyblueviper.com) before it executes. Not a rule engine — a judgment call on the specific order (symbol, side, size, type), issued by a party structurally separate from the agent placing it. This is the automated version of the README's own "review all actions proposed by the LLM carefully" guidance, not a replacement for that human review — most users will still want both.

Composes off the tool's own `destructiveHint` annotation rather than a hardcoded tool-name list, so `place_stock_order`/`place_crypto_order`/`place_option_order`/`cancel_order_by_id`/`cancel_all_orders`/`close_position`/`close_all_positions`/`replace_order_by_id` are all covered automatically, and any future destructive tool would be too, as long as it carries the annotation.

**Fails open by design** — any `/review`-side problem (network error, timeout, malformed response, missing key) and the order proceeds ungated. A `/review`-side outage should never be the reason a legitimate order gets stuck.

**Independently verifiable, not "trust us"** — every verdict can be recomputed via `/verify-proof` (free, no auth) against our published signing key.

## Usage (fully opt-in)

```python
from alpaca_mcp_server.invinoveritas_review import InvinoveritasReviewMiddleware

main.add_middleware(InvinoveritasReviewMiddleware(block_on_reject=True))  # or False for advisory-only
```

Requires `IVV_API_KEY` (free registration, no payment: `POST https://api.babyblueviper.com/register`). Does nothing — no network calls at all — if the key isn't set, so it's genuinely zero-cost to leave un-configured.

## Testing

```
pytest tests/test_invinoveritas_review.py -v
```

6/6 passing, real `FastMCP` `Client`/`Server` round-trip (not mocked internals) with HTTP mocked via `httpx.MockTransport` — no live Alpaca or invinoveritas credentials needed to run the suite. Covers: reject blocks a destructive call, a read-only tool is never reviewed at all, approve passes through, advisory mode never blocks, fails open on a network error, and skips the review entirely (zero calls) when no API key is configured.

Disabled unless explicitly wired via `add_middleware()` — same opt-in posture as the existing `TrustBoundaryMiddleware`, zero behavior change for anyone who doesn't add it. Happy to adjust anything (naming, default `artifact_type`, README placement) — first PR here, tried to match the repo's existing conventions as closely as possible rather than introduce a new pattern.