### PR TITLE
chore: bump version to 2.2.0 for PyPI release

### DIFF
--- a/.well-known/mcp/manifest.json
+++ b/.well-known/mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "GitHub MCP Registry Manifest",
   "_location": "/.well-known/mcp/manifest.json",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "schema_version": "0.2.0",
   "manifest_version": "0.3",
   "name": "alpaca-mcp-server",

--- a/charts/alpaca-mcp-server/Chart.yaml
+++ b/charts/alpaca-mcp-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.1"
+appVersion: "2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "alpaca-mcp-server"
-version = "2.1.1"
+version = "2.2.0"
 description = "Alpaca Trading API integration for Model Context Protocol (MCP)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/alpacahq/alpaca-mcp-server",
     "source": "github"
   },
-  "version": "2.1.1",
+  "version": "2.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "alpaca-mcp-server",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.yaml
+++ b/server.yaml
@@ -82,7 +82,7 @@ config:
 metadata:
   license: MIT
   maintainer: Alpaca <https://alpaca.markets/contact>
-  version: "2.1.1"
+  version: "2.2.0"
 
   docker:
     transport: stdio

--- a/src/alpaca_mcp_server/__init__.py
+++ b/src/alpaca_mcp_server/__init__.py
@@ -12,7 +12,7 @@ Key Features:
 - Corporate actions and market calendar
 """
 
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 __author__ = "Alpaca"
 __license__ = "MIT"
 __description__ = "Alpaca Trading API integration for Model Context Protocol (MCP)"

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "alpaca-mcp-server"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump the package and CLI version to 2.2.0
- align MCP registry, server metadata, Helm app version, and lockfile release metadata

## Test plan
- [x] Verified no 2.1.1 version references remain
- [ ] Build and publish the 2.2.0 distribution to PyPI after merging


Made with [Cursor](https://cursor.com)