### PR TITLE
Accept JSON string legs for option orders

### DIFF
--- a/src/alpaca_mcp_server/overrides.py
+++ b/src/alpaca_mcp_server/overrides.py
@@ -8,6 +8,7 @@ tools with curated parameters per asset class.
 
 from __future__ import annotations
 
+import json
 from typing import Optional
 
 import httpx
@@ -19,6 +20,22 @@ def _error(message: str, **extra: object) -> dict:
     err: dict = {"message": message}
     err.update(extra)
     return {"error": err}
+
+
+def _coerce_option_legs(legs: list[dict] | str | None) -> list[dict] | None | dict:
+    """Accept JSON-encoded legs from MCP clients that stringify arrays."""
+    if legs is None or isinstance(legs, list):
+        return legs
+
+    try:
+        parsed = json.loads(legs)
+    except json.JSONDecodeError as exc:
+        return _error("legs must be a JSON array or list of leg objects", detail=str(exc))
+
+    if not isinstance(parsed, list):
+        return _error("legs must decode to a JSON array")
+
+    return parsed
 
 
 async def _post_order(client: httpx.AsyncClient, body: dict) -> dict:
@@ -265,7 +282,7 @@ def register_order_tools(
         limit_price: Optional[str] = None,
         client_order_id: Optional[str] = None,
         order_class: Optional[str] = None,
-        legs: Optional[list[dict]] = None,
+        legs: list[dict] | str | None = None,
     ) -> dict:
         """Place an options order (single-leg or multi-leg).
 
@@ -281,8 +298,8 @@ def register_order_tools(
                  value (e.g., qty="10" with ratio_qty="2" = 20
                  contracts for that leg).
             type: "market" or "limit".
-            time_in_force: "day" only. Options do not support other
-                           values.
+            time_in_force: "day" (default) or another value accepted by
+                           Alpaca for the requested option order type.
             symbol: OCC option symbol (e.g., "AAPL250321C00150000").
                     Required for single-leg.
             side: "buy" or "sell". Required for single-leg.
@@ -298,11 +315,17 @@ def register_order_tools(
                              will reject duplicates. Recommended for every order.
             order_class: Set to "mleg" for multi-leg orders. Automatically
                          inferred when legs are provided.
-            legs: List of leg dicts for multi-leg orders (max 4). Each leg
-                  requires "symbol" and "ratio_qty" (string). Optional
-                  per-leg fields: "side" ("buy" or "sell") and
-                  "position_intent".
+            legs: List of leg dicts for multi-leg orders (max 4), or a
+                  JSON-encoded array when an MCP client stringifies complex
+                  arguments. Each leg requires "symbol" and "ratio_qty"
+                  (string). Optional per-leg fields: "side" ("buy" or
+                  "sell") and "position_intent".
         """
+        coerced_legs = _coerce_option_legs(legs)
+        if isinstance(coerced_legs, dict):
+            return coerced_legs
+        legs = coerced_legs
+
         is_multi_leg = legs is not None or order_class == "mleg"
 
         if is_multi_leg and legs is None:

--- a/src/alpaca_mcp_server/overrides.py
+++ b/src/alpaca_mcp_server/overrides.py
@@ -24,16 +24,24 @@ def _error(message: str, **extra: object) -> dict:
 
 def _coerce_option_legs(legs: list[dict] | str | None) -> list[dict] | None | dict:
     """Accept JSON-encoded legs from MCP clients that stringify arrays."""
-    if legs is None or isinstance(legs, list):
-        return legs
+    if legs is None:
+        return None
 
-    try:
-        parsed = json.loads(legs)
-    except json.JSONDecodeError as exc:
-        return _error("legs must be a JSON array or list of leg objects", detail=str(exc))
+    if isinstance(legs, str):
+        try:
+            parsed = json.loads(legs)
+        except json.JSONDecodeError as exc:
+            return _error(
+                "legs must be a JSON array of leg objects",
+                detail=str(exc),
+            )
+    else:
+        parsed = legs
 
-    if not isinstance(parsed, list):
-        return _error("legs must decode to a JSON array")
+    if not isinstance(parsed, list) or not all(
+        isinstance(leg, dict) for leg in parsed
+    ):
+        return _error("legs must be a JSON array of leg objects")
 
     return parsed
 

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -629,6 +629,68 @@ async def test_order_tools_have_destructive_hint():
         assert annotations.destructiveHint is True, f"{t.name} should have destructiveHint=True"
 
 
+async def test_place_option_order_accepts_json_string_legs():
+    """MCP clients may stringify complex array arguments before validation."""
+    captured: dict[str, Any] = {}
+
+    async def fake_post(self: Any, path: str, json: dict[str, Any]) -> Any:
+        captured["path"] = path
+        captured["json"] = json
+        return SimpleNamespace(is_error=False, json=lambda: {"id": "test-order"})
+
+    legs = [
+        {
+            "symbol": "SPY260731P00395000",
+            "ratio_qty": "1",
+            "side": "sell",
+            "position_intent": "sell_to_open",
+        },
+        {
+            "symbol": "SPY260731P00380000",
+            "ratio_qty": "1",
+            "side": "buy",
+            "position_intent": "buy_to_open",
+        },
+    ]
+
+    with patch("httpx.AsyncClient.post", fake_post):
+        result = await _call_tool(
+            "place_option_order",
+            {
+                "qty": "1",
+                "order_class": "mleg",
+                "type": "limit",
+                "limit_price": "-0.01",
+                "time_in_force": "gtc",
+                "legs": json.dumps(legs),
+            },
+        )
+
+    assert result[DATA_KEY] == {"id": "test-order"}
+    assert captured["path"] == "/v2/orders"
+    assert captured["json"]["legs"] == legs
+    assert captured["json"]["order_class"] == "mleg"
+    assert captured["json"]["time_in_force"] == "gtc"
+
+
+async def test_place_option_order_rejects_invalid_json_string_legs():
+    result = await _call_tool(
+        "place_option_order",
+        {
+            "qty": "1",
+            "order_class": "mleg",
+            "type": "limit",
+            "limit_price": "-0.01",
+            "legs": "not-json",
+        },
+        raise_on_error=False,
+    )
+
+    assert result[DATA_KEY]["error"]["message"] == (
+        "legs must be a JSON array or list of leg objects"
+    )
+
+
 async def test_toolset_filtering():
     """ALPACA_TOOLSETS should limit which tools are exposed."""
     tools = await _list_tools({**DUMMY_ENV, "ALPACA_TOOLSETS": "account"})

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -673,7 +673,15 @@ async def test_place_option_order_accepts_json_string_legs():
     assert captured["json"]["time_in_force"] == "gtc"
 
 
-async def test_place_option_order_rejects_invalid_json_string_legs():
+@pytest.mark.parametrize(
+    "legs",
+    [
+        "not-json",
+        json.dumps({"symbol": "SPY260731P00395000"}),
+        json.dumps(["not-an-object"]),
+    ],
+)
+async def test_place_option_order_rejects_invalid_json_string_legs(legs: str):
     result = await _call_tool(
         "place_option_order",
         {
@@ -681,13 +689,13 @@ async def test_place_option_order_rejects_invalid_json_string_legs():
             "order_class": "mleg",
             "type": "limit",
             "limit_price": "-0.01",
-            "legs": "not-json",
+            "legs": legs,
         },
         raise_on_error=False,
     )
 
     assert result[DATA_KEY]["error"]["message"] == (
-        "legs must be a JSON array or list of leg objects"
+        "legs must be a JSON array of leg objects"
     )
 
 


### PR DESCRIPTION
## Summary
- Accept JSON-encoded `legs` values for `place_option_order` so MCP clients that stringify complex array arguments can still place multi-leg option orders.
- Return a local validation error when `legs` is an invalid JSON string or does not decode to an array.
- Update the `time_in_force` docstring so it no longer says options are limited to `day` only.

Fixes #97

## Testing
- `python -m pytest tests/test_server_construction.py`
- `python -m py_compile src\alpaca_mcp_server\overrides.py tests\test_server_construction.py`
- `git diff --check`