### PR TITLE
Strip OpenAPI vendor extensions from tool schemas

### DIFF
--- a/src/alpaca_mcp_server/server.py
+++ b/src/alpaca_mcp_server/server.py
@@ -45,9 +45,23 @@ def get_mcp_user_agent() -> str:
     return f"APCA-MCP-TRADING/{strip_v_from_version(release_version)}"
 
 
+def _strip_openapi_vendor_extensions(value: Any) -> Any:
+    """Recursively remove OpenAPI vendor extensions before tool generation."""
+    if isinstance(value, dict):
+        return {
+            key: _strip_openapi_vendor_extensions(item)
+            for key, item in value.items()
+            if not key.startswith("x-")
+        }
+    if isinstance(value, list):
+        return [_strip_openapi_vendor_extensions(item) for item in value]
+    return value
+
+
 def _load_spec(name: str) -> dict[str, Any]:
     path = SPECS_DIR / f"{name}.json"
-    return json.loads(path.read_text(encoding="utf-8"))
+    spec = json.loads(path.read_text(encoding="utf-8"))
+    return _strip_openapi_vendor_extensions(spec)
 
 
 def _make_filter(allowed_ops: set[str]):

--- a/src/alpaca_mcp_server/server.py
+++ b/src/alpaca_mcp_server/server.py
@@ -45,14 +45,27 @@ def get_mcp_user_agent() -> str:
     return f"APCA-MCP-TRADING/{strip_v_from_version(release_version)}"
 
 
+_OPENAPI_LITERAL_FIELDS = frozenset({"default", "example", "examples"})
+_OPENAPI_NAMED_MAP_FIELDS = frozenset({"properties", "schemas"})
+
+
 def _strip_openapi_vendor_extensions(value: Any) -> Any:
-    """Recursively remove OpenAPI vendor extensions before tool generation."""
+    """Remove extensions without dropping x-prefixed schema data."""
     if isinstance(value, dict):
-        return {
-            key: _strip_openapi_vendor_extensions(item)
-            for key, item in value.items()
-            if not key.startswith("x-")
-        }
+        cleaned: dict[str, Any] = {}
+        for key, item in value.items():
+            if key.startswith("x-"):
+                continue
+            if key in _OPENAPI_LITERAL_FIELDS:
+                cleaned[key] = item
+            elif key in _OPENAPI_NAMED_MAP_FIELDS and isinstance(item, dict):
+                cleaned[key] = {
+                    name: _strip_openapi_vendor_extensions(entry)
+                    for name, entry in item.items()
+                }
+            else:
+                cleaned[key] = _strip_openapi_vendor_extensions(item)
+        return cleaned
     if isinstance(value, list):
         return [_strip_openapi_vendor_extensions(item) for item in value]
     return value

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -28,6 +28,7 @@ from alpaca_mcp_server.security import DATA_KEY, SECURITY_KEY
 from alpaca_mcp_server.server import (
     _build_auth_headers,
     _make_api_client,
+    _strip_openapi_vendor_extensions,
     build_server,
     get_mcp_user_agent,
     strip_v_from_version,
@@ -317,6 +318,38 @@ async def test_empty_user_agent_opts_out():
 )
 def test_strip_v_from_version(release_version: str, expected: str) -> None:
     assert strip_v_from_version(release_version) == expected
+
+
+def test_strip_openapi_vendor_extensions_recursively():
+    spec = {
+        "type": "object",
+        "x-stoplight": {"id": "schema"},
+        "properties": {
+            "start": {
+                "type": "string",
+                "x-go-type": "legacyTime",
+                "examples": ["2026-01-01"],
+            },
+            "nested": [
+                {"x-go-name": "Foo", "description": "kept"},
+                "value",
+            ],
+        },
+    }
+
+    assert _strip_openapi_vendor_extensions(spec) == {
+        "type": "object",
+        "properties": {
+            "start": {
+                "type": "string",
+                "examples": ["2026-01-01"],
+            },
+            "nested": [
+                {"description": "kept"},
+                "value",
+            ],
+        },
+    }
 
 
 async def test_tool_count():

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -322,32 +322,39 @@ def test_strip_v_from_version(release_version: str, expected: str) -> None:
 
 def test_strip_openapi_vendor_extensions_recursively():
     spec = {
-        "type": "object",
         "x-stoplight": {"id": "schema"},
         "properties": {
-            "start": {
-                "type": "string",
-                "x-go-type": "legacyTime",
-                "examples": ["2026-01-01"],
+            "x-symbol": {
+                "type": "object",
+                "x-go-type": "legacySymbol",
+                "default": {"x-source": "user"},
+                "example": {"x-value": 1},
             },
-            "nested": [
-                {"x-go-name": "Foo", "description": "kept"},
-                "value",
-            ],
+        },
+        "components": {
+            "schemas": {
+                "x-Order": {
+                    "type": "string",
+                    "x-go-type": "legacyOrder",
+                },
+            },
         },
     }
 
     assert _strip_openapi_vendor_extensions(spec) == {
-        "type": "object",
         "properties": {
-            "start": {
-                "type": "string",
-                "examples": ["2026-01-01"],
+            "x-symbol": {
+                "type": "object",
+                "default": {"x-source": "user"},
+                "example": {"x-value": 1},
             },
-            "nested": [
-                {"description": "kept"},
-                "value",
-            ],
+        },
+        "components": {
+            "schemas": {
+                "x-Order": {
+                    "type": "string",
+                },
+            },
         },
     }
 


### PR DESCRIPTION
﻿## Summary
- Recursively strip OpenAPI vendor extension keys (`x-*`) when loading bundled specs before FastMCP builds tool schemas.
- Preserve ordinary schema fields such as `examples`, `description`, and `properties`.
- Add a regression test for nested dict/list stripping behavior.

Fixes #71

## Testing
- `python -m pytest tests/test_server_construction.py -k "vendor_extensions or tool_count or tool_names_match"`
- `python -m pytest tests/test_server_construction.py`
- `python -m ruff check src/alpaca_mcp_server/server.py`
- `python -m py_compile src\alpaca_mcp_server\server.py tests\test_server_construction.py`
- `git diff --check`

Note: `ruff check src/alpaca_mcp_server/server.py tests/test_server_construction.py` still reports pre-existing typing/import style findings in `tests/test_server_construction.py`; this PR does not reformat that file beyond the focused regression import/test.
