### PR TITLE
fix: flatten one-branch allOf so sort enums are visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run core tests
-        run: pytest tests/test_integrity.py tests/test_server_construction.py
+        run: pytest tests/test_integrity.py tests/test_server_construction.py tests/test_schema_compat.py
 
   # ── Job 2: Integration tests (paper API, secrets required) ────────────
   # Runs only on pushes to main and PRs from the same repo (not forks).

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ alpaca-mcp-server/
 │       ├── overrides.py      ← Hand-crafted tools for complex trading endpoints
 │       ├── market_data_overrides.py ← Hand-crafted tools for historical data
 │       ├── readme_docs.py    ← Read-only proxy tools for Alpaca ReadMe docs
-│       ├── schema_compat.py  ← Tool schema normalization for strict clients (Gemini)
+│       ├── schema_compat.py  ← Flatten one-branch allOf so enum values are visible
 │       └── specs/
 │           ├── trading-api.json
 │           └── market-data-api.json
@@ -559,7 +559,7 @@ alpaca-mcp-server/
 │   ├── conftest.py           ← Shared fixtures and paper-account cleanup
 │   ├── test_integrity.py     ← Spec ↔ toolset ↔ names consistency checks
 │   ├── test_server_construction.py ← Server build verification
-│   ├── test_schema_compat.py ← Tool schema compatibility checks
+│   ├── test_schema_compat.py ← Flattening of one-branch allOf wrappers
 │   ├── test_readme_integration.py ← Live ReadMe docs MCP integration tests
 │   └── test_paper_integration.py   ← Paper API integration tests
 ├── scripts/

--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ alpaca-mcp-server/
 │       ├── overrides.py      ← Hand-crafted tools for complex trading endpoints
 │       ├── market_data_overrides.py ← Hand-crafted tools for historical data
 │       ├── readme_docs.py    ← Read-only proxy tools for Alpaca ReadMe docs
+│       ├── schema_compat.py  ← Tool schema normalization for strict clients (Gemini)
 │       └── specs/
 │           ├── trading-api.json
 │           └── market-data-api.json
@@ -558,6 +559,7 @@ alpaca-mcp-server/
 │   ├── conftest.py           ← Shared fixtures and paper-account cleanup
 │   ├── test_integrity.py     ← Spec ↔ toolset ↔ names consistency checks
 │   ├── test_server_construction.py ← Server build verification
+│   ├── test_schema_compat.py ← Tool schema compatibility checks
 │   ├── test_readme_integration.py ← Live ReadMe docs MCP integration tests
 │   └── test_paper_integration.py   ← Paper API integration tests
 ├── scripts/

--- a/src/alpaca_mcp_server/schema_compat.py
+++ b/src/alpaca_mcp_server/schema_compat.py
@@ -1,0 +1,181 @@
+"""
+Schema compatibility for strict function-calling APIs.
+
+Gemini's function-calling API validates tool schemas against a fixed subset of
+JSON Schema and returns HTTP 400 for anything outside it, which kills every
+chat turn that includes an affected tool. Four things FastMCP emits fall
+outside that subset, and this module rewrites them when tools are listed:
+
+- ``allOf``, which Gemini has no equivalent for
+- the plural ``examples`` array, where Gemini reads a singular ``example``
+- a ``type`` array such as ``["string", "null"]``, where Gemini takes one type
+- an ``enum`` of numbers, where Gemini requires strings
+
+These apply for every client rather than sitting behind a compatibility flag.
+The ``allOf`` and ``type`` rewrites are exact. The other two keep less detail —
+the first example rather than all of them, and a numeric range rather than the
+exact values — which the parameter descriptions already spell out.
+
+Flattening ``allOf`` also fixes a real bug: Alpaca's specs wrap enum parameters
+in a single-branch ``allOf``, which hides the allowed values from any client
+that does not merge it.
+
+This runs at ``tools/list`` time because that is the only point where schemas
+are fully resolved. Earlier hooks still contain ``$ref`` pointers into a
+``$defs`` block that FastMCP inlines afterwards.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import Tool
+
+# Accepted by Gemini's Schema proto. Sourced from google.genai.types.Schema.
+GEMINI_SCHEMA_KEYWORDS = frozenset(
+    {
+        "additionalProperties",
+        "anyOf",
+        "default",
+        "description",
+        "enum",
+        "example",
+        "format",
+        "items",
+        "maxItems",
+        "maxLength",
+        "maxProperties",
+        "maximum",
+        "minItems",
+        "minLength",
+        "minProperties",
+        "minimum",
+        "nullable",
+        "pattern",
+        "properties",
+        "propertyOrdering",
+        "required",
+        "title",
+        "type",
+        "$defs",
+        "$ref",
+    }
+)
+
+# Keys whose values are arbitrary data rather than nested schemas.
+_LITERAL_FIELDS = frozenset({"const", "default", "example", "examples"})
+
+# Keys whose child keys are author-chosen names rather than schema keywords.
+_NAMED_MAP_FIELDS = frozenset({"properties", "$defs", "definitions", "patternProperties"})
+
+
+def _merge_single_branch_allof(node: dict[str, Any]) -> dict[str, Any]:
+    """Merge a one-branch ``allOf`` into its parent.
+
+    A single branch is an identity, so merging cannot change what the schema
+    accepts. Sibling keys win on conflict because they are the narrower
+    override.
+    """
+    branches = node.get("allOf")
+    if not isinstance(branches, list) or len(branches) != 1:
+        return node
+    if not isinstance(branches[0], dict):
+        return node
+
+    merged = dict(branches[0])
+    for key, value in node.items():
+        if key != "allOf":
+            merged[key] = value
+    return merged
+
+
+def _singularize_examples(node: dict[str, Any]) -> dict[str, Any]:
+    """Replace an ``examples`` array with the singular ``example`` Gemini reads."""
+    examples = node.get("examples")
+    if not isinstance(examples, list) or not examples:
+        return node
+
+    normalized = {key: value for key, value in node.items() if key != "examples"}
+    normalized.setdefault("example", examples[0])
+    return normalized
+
+
+def _split_type_union(node: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite a ``type`` array as ``anyOf``, which Gemini accepts.
+
+    One branch per type is exactly equivalent, and it is already the form
+    FastMCP produces for other nullable parameters.
+    """
+    types = node.get("type")
+    if not isinstance(types, list) or not types or "anyOf" in node:
+        return node
+
+    rest = {key: value for key, value in node.items() if key != "type"}
+    if len(types) == 1:
+        return {"type": types[0], **rest}
+    return {"anyOf": [{"type": entry} for entry in types], **rest}
+
+
+def _drop_non_string_enum(node: dict[str, Any]) -> dict[str, Any]:
+    """Drop an ``enum`` of numbers, keeping its range as ``minimum``/``maximum``.
+
+    Gemini's ``enum`` holds strings only. Stringifying the values would invite
+    a client to send ``"2"`` where the API needs ``2``, so the bounds are kept
+    instead. Descriptions for these parameters already spell out each value.
+    """
+    values = node.get("enum")
+    if not isinstance(values, list) or not values:
+        return node
+    if all(isinstance(value, str) for value in values):
+        return node
+
+    normalized = {key: value for key, value in node.items() if key != "enum"}
+    numbers = [
+        value
+        for value in values
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    ]
+    if len(numbers) == len(values):
+        normalized.setdefault("minimum", min(numbers))
+        normalized.setdefault("maximum", max(numbers))
+    return normalized
+
+
+def normalize_tool_schema(value: Any) -> Any:
+    """Rewrite schema keywords that strict function-calling APIs reject."""
+    if isinstance(value, list):
+        return [normalize_tool_schema(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    node: dict[str, Any] = {}
+    for key, item in value.items():
+        if key in _LITERAL_FIELDS:
+            node[key] = item
+        elif key in _NAMED_MAP_FIELDS and isinstance(item, dict):
+            node[key] = {
+                name: normalize_tool_schema(entry) for name, entry in item.items()
+            }
+        else:
+            node[key] = normalize_tool_schema(item)
+
+    node = _merge_single_branch_allof(node)
+    node = _split_type_union(node)
+    node = _drop_non_string_enum(node)
+    return _singularize_examples(node)
+
+
+class SchemaCompatMiddleware(Middleware):
+    """Normalizes advertised tool schemas for strict function-calling clients."""
+
+    async def on_list_tools(
+        self, context: MiddlewareContext, call_next
+    ) -> list[Tool]:
+        tools = await call_next(context)
+        return [
+            tool.model_copy(update={"parameters": normalize_tool_schema(tool.parameters)})
+            if isinstance(tool.parameters, dict)
+            else tool
+            for tool in tools
+        ]

--- a/src/alpaca_mcp_server/schema_compat.py
+++ b/src/alpaca_mcp_server/schema_compat.py
@@ -1,24 +1,11 @@
 """
-Schema compatibility for strict function-calling APIs.
+Flatten one-branch ``allOf`` wrappers in advertised tool schemas.
 
-Gemini's function-calling API validates tool schemas against a fixed subset of
-JSON Schema and returns HTTP 400 for anything outside it, which kills every
-chat turn that includes an affected tool. Four things FastMCP emits fall
-outside that subset, and this module rewrites them when tools are listed:
-
-- ``allOf``, which Gemini has no equivalent for
-- the plural ``examples`` array, where Gemini reads a singular ``example``
-- a ``type`` array such as ``["string", "null"]``, where Gemini takes one type
-- an ``enum`` of numbers, where Gemini requires strings
-
-These apply for every client rather than sitting behind a compatibility flag.
-The ``allOf`` and ``type`` rewrites are exact. The other two keep less detail —
-the first example rather than all of them, and a numeric range rather than the
-exact values — which the parameter descriptions already spell out.
-
-Flattening ``allOf`` also fixes a real bug: Alpaca's specs wrap enum parameters
-in a single-branch ``allOf``, which hides the allowed values from any client
-that does not merge it.
+FastMCP leaves query-parameter enums wrapped as
+``{"allOf": [{"$ref": "..."}]}``. After ``$ref`` is inlined, clients that do
+not merge ``allOf`` never see the ``enum`` — so the model has to guess
+``asc``/``desc`` on sort parameters. A one-branch ``allOf`` is an identity,
+so flattening it does not change what the schema accepts.
 
 This runs at ``tools/list`` time because that is the only point where schemas
 are fully resolved. Earlier hooks still contain ``$ref`` pointers into a
@@ -32,37 +19,6 @@ from typing import Any
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools.tool import Tool
 
-# Accepted by Gemini's Schema proto. Sourced from google.genai.types.Schema.
-GEMINI_SCHEMA_KEYWORDS = frozenset(
-    {
-        "additionalProperties",
-        "anyOf",
-        "default",
-        "description",
-        "enum",
-        "example",
-        "format",
-        "items",
-        "maxItems",
-        "maxLength",
-        "maxProperties",
-        "maximum",
-        "minItems",
-        "minLength",
-        "minProperties",
-        "minimum",
-        "nullable",
-        "pattern",
-        "properties",
-        "propertyOrdering",
-        "required",
-        "title",
-        "type",
-        "$defs",
-        "$ref",
-    }
-)
-
 # Keys whose values are arbitrary data rather than nested schemas.
 _LITERAL_FIELDS = frozenset({"const", "default", "example", "examples"})
 
@@ -73,9 +29,9 @@ _NAMED_MAP_FIELDS = frozenset({"properties", "$defs", "definitions", "patternPro
 def _merge_single_branch_allof(node: dict[str, Any]) -> dict[str, Any]:
     """Merge a one-branch ``allOf`` into its parent.
 
-    A single branch is an identity, so merging cannot change what the schema
-    accepts. Sibling keys win on conflict because they are the narrower
-    override.
+    Sibling keys win on conflict because they are the narrower override.
+    Multi-branch ``allOf`` is left alone — merging it would change the
+    intersection.
     """
     branches = node.get("allOf")
     if not isinstance(branches, list) or len(branches) != 1:
@@ -90,62 +46,10 @@ def _merge_single_branch_allof(node: dict[str, Any]) -> dict[str, Any]:
     return merged
 
 
-def _singularize_examples(node: dict[str, Any]) -> dict[str, Any]:
-    """Replace an ``examples`` array with the singular ``example`` Gemini reads."""
-    examples = node.get("examples")
-    if not isinstance(examples, list) or not examples:
-        return node
-
-    normalized = {key: value for key, value in node.items() if key != "examples"}
-    normalized.setdefault("example", examples[0])
-    return normalized
-
-
-def _split_type_union(node: dict[str, Any]) -> dict[str, Any]:
-    """Rewrite a ``type`` array as ``anyOf``, which Gemini accepts.
-
-    One branch per type is exactly equivalent, and it is already the form
-    FastMCP produces for other nullable parameters.
-    """
-    types = node.get("type")
-    if not isinstance(types, list) or not types or "anyOf" in node:
-        return node
-
-    rest = {key: value for key, value in node.items() if key != "type"}
-    if len(types) == 1:
-        return {"type": types[0], **rest}
-    return {"anyOf": [{"type": entry} for entry in types], **rest}
-
-
-def _drop_non_string_enum(node: dict[str, Any]) -> dict[str, Any]:
-    """Drop an ``enum`` of numbers, keeping its range as ``minimum``/``maximum``.
-
-    Gemini's ``enum`` holds strings only. Stringifying the values would invite
-    a client to send ``"2"`` where the API needs ``2``, so the bounds are kept
-    instead. Descriptions for these parameters already spell out each value.
-    """
-    values = node.get("enum")
-    if not isinstance(values, list) or not values:
-        return node
-    if all(isinstance(value, str) for value in values):
-        return node
-
-    normalized = {key: value for key, value in node.items() if key != "enum"}
-    numbers = [
-        value
-        for value in values
-        if isinstance(value, (int, float)) and not isinstance(value, bool)
-    ]
-    if len(numbers) == len(values):
-        normalized.setdefault("minimum", min(numbers))
-        normalized.setdefault("maximum", max(numbers))
-    return normalized
-
-
-def normalize_tool_schema(value: Any) -> Any:
-    """Rewrite schema keywords that strict function-calling APIs reject."""
+def flatten_single_branch_allof(value: Any) -> Any:
+    """Walk a schema and flatten every one-branch ``allOf``."""
     if isinstance(value, list):
-        return [normalize_tool_schema(item) for item in value]
+        return [flatten_single_branch_allof(item) for item in value]
     if not isinstance(value, dict):
         return value
 
@@ -155,26 +59,25 @@ def normalize_tool_schema(value: Any) -> Any:
             node[key] = item
         elif key in _NAMED_MAP_FIELDS and isinstance(item, dict):
             node[key] = {
-                name: normalize_tool_schema(entry) for name, entry in item.items()
+                name: flatten_single_branch_allof(entry) for name, entry in item.items()
             }
         else:
-            node[key] = normalize_tool_schema(item)
+            node[key] = flatten_single_branch_allof(item)
 
-    node = _merge_single_branch_allof(node)
-    node = _split_type_union(node)
-    node = _drop_non_string_enum(node)
-    return _singularize_examples(node)
+    return _merge_single_branch_allof(node)
 
 
 class SchemaCompatMiddleware(Middleware):
-    """Normalizes advertised tool schemas for strict function-calling clients."""
+    """Flattens one-branch ``allOf`` on advertised tool schemas."""
 
     async def on_list_tools(
         self, context: MiddlewareContext, call_next
     ) -> list[Tool]:
         tools = await call_next(context)
         return [
-            tool.model_copy(update={"parameters": normalize_tool_schema(tool.parameters)})
+            tool.model_copy(
+                update={"parameters": flatten_single_branch_allof(tool.parameters)}
+            )
             if isinstance(tool.parameters, dict)
             else tool
             for tool in tools

--- a/src/alpaca_mcp_server/server.py
+++ b/src/alpaca_mcp_server/server.py
@@ -20,6 +20,7 @@ from fastmcp import FastMCP
 from fastmcp.server.providers.openapi.routing import MCPType
 
 from .readme_docs import ReadMeClientFactory, register_readme_docs_tools
+from .schema_compat import SchemaCompatMiddleware
 from .security import TrustBoundaryMiddleware
 from .tool_registry import TOOL_DESCRIPTIONS, TOOL_NAMES
 from .toolsets import OVERRIDE_OPERATION_IDS, TOOLSETS, get_active_operations
@@ -172,6 +173,7 @@ def build_server(
 
     main = FastMCP("Alpaca MCP Server", lifespan=lifespan)
     main.add_middleware(TrustBoundaryMiddleware())
+    main.add_middleware(SchemaCompatMiddleware())
 
     if trading_client is not None:
         allowed = spec_ops["trading"]

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -1,17 +1,11 @@
 """
-Tests for schema normalization aimed at strict function-calling clients.
+Tests for flattening one-branch allOf wrappers in tool schemas.
 
 Covers:
 - Single-branch allOf is merged so the enum it hides becomes visible
 - Multi-branch allOf is left alone
-- The plural examples array becomes the singular example Gemini reads
-- A type array becomes anyOf, and a numeric enum becomes a numeric range
 - Author-chosen names and literal data are not mistaken for schema keywords
-- Every advertised tool schema stays inside what Gemini accepts
-
-The rules asserted here were derived by validating the real tool schemas
-against ``google.genai.types.Schema``, which is generated from the same proto
-the Gemini endpoint parses.
+- Advertised sort parameters expose their enum to clients
 """
 
 from __future__ import annotations
@@ -21,10 +15,7 @@ from unittest.mock import patch
 
 from fastmcp.client import Client
 
-from alpaca_mcp_server.schema_compat import (
-    GEMINI_SCHEMA_KEYWORDS,
-    normalize_tool_schema,
-)
+from alpaca_mcp_server.schema_compat import flatten_single_branch_allof
 from alpaca_mcp_server.server import build_server
 
 DUMMY_ENV = {
@@ -32,39 +23,6 @@ DUMMY_ENV = {
     "ALPACA_SECRET_KEY": "test-secret",
     "ALPACA_PAPER_TRADE": "true",
 }
-
-# Positions where a nested value is itself a schema, so recursion must continue.
-_NAMED_MAPS = frozenset({"properties", "$defs", "definitions", "patternProperties"})
-_SUB_SCHEMAS = frozenset(
-    {"items", "additionalProperties", "not", "if", "then", "else", "contains"}
-)
-_SCHEMA_LISTS = frozenset({"anyOf", "oneOf", "allOf", "prefixItems"})
-_LITERALS = frozenset({"const", "default", "example", "examples"})
-
-
-def _collect_violations(schema, path: str, found: list[str]) -> None:
-    """Walk a schema and record anything Gemini's Schema proto would reject."""
-    if not isinstance(schema, dict):
-        return
-    for key, value in schema.items():
-        if key not in GEMINI_SCHEMA_KEYWORDS:
-            found.append(f"{path}: unsupported keyword {key!r}")
-        if key == "type" and isinstance(value, list):
-            found.append(f"{path}: type must be a single value, got {value!r}")
-        if key == "enum" and isinstance(value, list):
-            non_strings = [v for v in value if not isinstance(v, str)]
-            if non_strings:
-                found.append(f"{path}: enum must be strings, got {non_strings!r}")
-        if key in _LITERALS:
-            continue
-        if key in _NAMED_MAPS and isinstance(value, dict):
-            for name, entry in value.items():
-                _collect_violations(entry, f"{path}.{name}", found)
-        elif key in _SUB_SCHEMAS:
-            _collect_violations(value, f"{path}.{key}", found)
-        elif key in _SCHEMA_LISTS and isinstance(value, list):
-            for index, entry in enumerate(value):
-                _collect_violations(entry, f"{path}.{key}[{index}]", found)
 
 
 async def _list_tools() -> list:
@@ -89,7 +47,7 @@ def test_single_branch_allof_is_merged():
         "description": "from the sibling",
     }
 
-    assert normalize_tool_schema(schema) == {
+    assert flatten_single_branch_allof(schema) == {
         "type": "string",
         "enum": ["asc", "desc"],
         "default": "asc",
@@ -102,7 +60,7 @@ def test_multi_branch_allof_is_left_alone():
     """Merging an intersection of two branches would change what it accepts."""
     schema = {"allOf": [{"type": "string"}, {"maxLength": 4}]}
 
-    assert normalize_tool_schema(schema) == schema
+    assert flatten_single_branch_allof(schema) == schema
 
 
 def test_nested_single_branch_allof_is_merged():
@@ -113,54 +71,10 @@ def test_nested_single_branch_allof_is_merged():
         },
     }
 
-    assert normalize_tool_schema(schema) == {
+    assert flatten_single_branch_allof(schema) == {
         "type": "object",
         "properties": {"sort": {"enum": ["asc"], "type": "string"}},
     }
-
-
-def test_examples_array_becomes_singular_example():
-    schema = {"type": "string", "examples": ["FILL", "TRANS"]}
-
-    assert normalize_tool_schema(schema) == {"type": "string", "example": "FILL"}
-
-
-def test_existing_example_survives_examples_removal():
-    schema = {"type": "string", "example": "kept", "examples": ["dropped"]}
-
-    assert normalize_tool_schema(schema) == {"type": "string", "example": "kept"}
-
-
-def test_type_array_becomes_anyof():
-    schema = {"type": ["string", "null"], "description": "kept"}
-
-    assert normalize_tool_schema(schema) == {
-        "anyOf": [{"type": "string"}, {"type": "null"}],
-        "description": "kept",
-    }
-
-
-def test_single_entry_type_array_becomes_a_plain_type():
-    schema = {"type": ["string"]}
-
-    assert normalize_tool_schema(schema) == {"type": "string"}
-
-
-def test_numeric_enum_becomes_a_range():
-    schema = {"type": "integer", "enum": [0, 1, 2, 3], "description": "0=off"}
-
-    assert normalize_tool_schema(schema) == {
-        "type": "integer",
-        "description": "0=off",
-        "minimum": 0,
-        "maximum": 3,
-    }
-
-
-def test_string_enum_is_kept():
-    schema = {"type": "string", "enum": ["asc", "desc"]}
-
-    assert normalize_tool_schema(schema) == schema
 
 
 def test_property_named_like_a_keyword_is_not_treated_as_one():
@@ -169,36 +83,24 @@ def test_property_named_like_a_keyword_is_not_treated_as_one():
         "type": "object",
         "properties": {
             "allOf": {"type": "string"},
-            "examples": {"type": "string"},
         },
     }
 
-    assert normalize_tool_schema(schema) == schema
+    assert flatten_single_branch_allof(schema) == schema
 
 
 def test_literal_data_is_not_rewritten():
     """default holds a value, so keys inside it are data and must be untouched."""
-    schema = {"type": "object", "default": {"allOf": 1, "examples": [2]}}
+    schema = {"type": "object", "default": {"allOf": [{"enum": ["x"]}]}}
 
-    assert normalize_tool_schema(schema) == schema
-
-
-def test_normalization_is_idempotent():
-    schema = {"allOf": [{"enum": ["asc"]}], "type": "string", "examples": ["asc"]}
-    once = normalize_tool_schema(schema)
-
-    assert normalize_tool_schema(once) == once
+    assert flatten_single_branch_allof(schema) == schema
 
 
-async def test_tool_schemas_are_gemini_compatible():
-    """Guards issue #71: one rejected tool makes Gemini 400 the whole request."""
-    tools = await _list_tools()
+def test_flattening_is_idempotent():
+    schema = {"allOf": [{"enum": ["asc"]}], "type": "string"}
+    once = flatten_single_branch_allof(schema)
 
-    violations: list[str] = []
-    for tool in tools:
-        _collect_violations(tool.inputSchema or {}, tool.name, violations)
-
-    assert not violations, "Gemini would reject:\n" + "\n".join(sorted(violations))
+    assert flatten_single_branch_allof(once) == once
 
 
 async def test_sort_enum_is_visible_to_clients():

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -1,0 +1,211 @@
+"""
+Tests for schema normalization aimed at strict function-calling clients.
+
+Covers:
+- Single-branch allOf is merged so the enum it hides becomes visible
+- Multi-branch allOf is left alone
+- The plural examples array becomes the singular example Gemini reads
+- A type array becomes anyOf, and a numeric enum becomes a numeric range
+- Author-chosen names and literal data are not mistaken for schema keywords
+- Every advertised tool schema stays inside what Gemini accepts
+
+The rules asserted here were derived by validating the real tool schemas
+against ``google.genai.types.Schema``, which is generated from the same proto
+the Gemini endpoint parses.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from fastmcp.client import Client
+
+from alpaca_mcp_server.schema_compat import (
+    GEMINI_SCHEMA_KEYWORDS,
+    normalize_tool_schema,
+)
+from alpaca_mcp_server.server import build_server
+
+DUMMY_ENV = {
+    "ALPACA_API_KEY": "test-key",
+    "ALPACA_SECRET_KEY": "test-secret",
+    "ALPACA_PAPER_TRADE": "true",
+}
+
+# Positions where a nested value is itself a schema, so recursion must continue.
+_NAMED_MAPS = frozenset({"properties", "$defs", "definitions", "patternProperties"})
+_SUB_SCHEMAS = frozenset(
+    {"items", "additionalProperties", "not", "if", "then", "else", "contains"}
+)
+_SCHEMA_LISTS = frozenset({"anyOf", "oneOf", "allOf", "prefixItems"})
+_LITERALS = frozenset({"const", "default", "example", "examples"})
+
+
+def _collect_violations(schema, path: str, found: list[str]) -> None:
+    """Walk a schema and record anything Gemini's Schema proto would reject."""
+    if not isinstance(schema, dict):
+        return
+    for key, value in schema.items():
+        if key not in GEMINI_SCHEMA_KEYWORDS:
+            found.append(f"{path}: unsupported keyword {key!r}")
+        if key == "type" and isinstance(value, list):
+            found.append(f"{path}: type must be a single value, got {value!r}")
+        if key == "enum" and isinstance(value, list):
+            non_strings = [v for v in value if not isinstance(v, str)]
+            if non_strings:
+                found.append(f"{path}: enum must be strings, got {non_strings!r}")
+        if key in _LITERALS:
+            continue
+        if key in _NAMED_MAPS and isinstance(value, dict):
+            for name, entry in value.items():
+                _collect_violations(entry, f"{path}.{name}", found)
+        elif key in _SUB_SCHEMAS:
+            _collect_violations(value, f"{path}.{key}", found)
+        elif key in _SCHEMA_LISTS and isinstance(value, list):
+            for index, entry in enumerate(value):
+                _collect_violations(entry, f"{path}.{key}[{index}]", found)
+
+
+async def _list_tools() -> list:
+    with patch.dict(os.environ, DUMMY_ENV, clear=False):
+        server = build_server()
+    async with Client(transport=server) as c:
+        return await c.list_tools()
+
+
+def test_single_branch_allof_is_merged():
+    """The branch's enum and default must survive the merge."""
+    schema = {
+        "allOf": [
+            {
+                "type": "string",
+                "enum": ["asc", "desc"],
+                "default": "asc",
+                "description": "from the branch",
+            }
+        ],
+        "type": "string",
+        "description": "from the sibling",
+    }
+
+    assert normalize_tool_schema(schema) == {
+        "type": "string",
+        "enum": ["asc", "desc"],
+        "default": "asc",
+        # The sibling is the narrower override, so it wins.
+        "description": "from the sibling",
+    }
+
+
+def test_multi_branch_allof_is_left_alone():
+    """Merging an intersection of two branches would change what it accepts."""
+    schema = {"allOf": [{"type": "string"}, {"maxLength": 4}]}
+
+    assert normalize_tool_schema(schema) == schema
+
+
+def test_nested_single_branch_allof_is_merged():
+    schema = {
+        "type": "object",
+        "properties": {
+            "sort": {"allOf": [{"enum": ["asc"]}], "type": "string"},
+        },
+    }
+
+    assert normalize_tool_schema(schema) == {
+        "type": "object",
+        "properties": {"sort": {"enum": ["asc"], "type": "string"}},
+    }
+
+
+def test_examples_array_becomes_singular_example():
+    schema = {"type": "string", "examples": ["FILL", "TRANS"]}
+
+    assert normalize_tool_schema(schema) == {"type": "string", "example": "FILL"}
+
+
+def test_existing_example_survives_examples_removal():
+    schema = {"type": "string", "example": "kept", "examples": ["dropped"]}
+
+    assert normalize_tool_schema(schema) == {"type": "string", "example": "kept"}
+
+
+def test_type_array_becomes_anyof():
+    schema = {"type": ["string", "null"], "description": "kept"}
+
+    assert normalize_tool_schema(schema) == {
+        "anyOf": [{"type": "string"}, {"type": "null"}],
+        "description": "kept",
+    }
+
+
+def test_single_entry_type_array_becomes_a_plain_type():
+    schema = {"type": ["string"]}
+
+    assert normalize_tool_schema(schema) == {"type": "string"}
+
+
+def test_numeric_enum_becomes_a_range():
+    schema = {"type": "integer", "enum": [0, 1, 2, 3], "description": "0=off"}
+
+    assert normalize_tool_schema(schema) == {
+        "type": "integer",
+        "description": "0=off",
+        "minimum": 0,
+        "maximum": 3,
+    }
+
+
+def test_string_enum_is_kept():
+    schema = {"type": "string", "enum": ["asc", "desc"]}
+
+    assert normalize_tool_schema(schema) == schema
+
+
+def test_property_named_like_a_keyword_is_not_treated_as_one():
+    """Keys under properties are author-chosen names, not schema keywords."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "allOf": {"type": "string"},
+            "examples": {"type": "string"},
+        },
+    }
+
+    assert normalize_tool_schema(schema) == schema
+
+
+def test_literal_data_is_not_rewritten():
+    """default holds a value, so keys inside it are data and must be untouched."""
+    schema = {"type": "object", "default": {"allOf": 1, "examples": [2]}}
+
+    assert normalize_tool_schema(schema) == schema
+
+
+def test_normalization_is_idempotent():
+    schema = {"allOf": [{"enum": ["asc"]}], "type": "string", "examples": ["asc"]}
+    once = normalize_tool_schema(schema)
+
+    assert normalize_tool_schema(once) == once
+
+
+async def test_tool_schemas_are_gemini_compatible():
+    """Guards issue #71: one rejected tool makes Gemini 400 the whole request."""
+    tools = await _list_tools()
+
+    violations: list[str] = []
+    for tool in tools:
+        _collect_violations(tool.inputSchema or {}, tool.name, violations)
+
+    assert not violations, "Gemini would reject:\n" + "\n".join(sorted(violations))
+
+
+async def test_sort_enum_is_visible_to_clients():
+    """The enum used to be buried in an allOf that most clients never merge."""
+    tools = {t.name: t.inputSchema for t in await _list_tools()}
+
+    for name in ("get_option_bars", "get_option_trades", "get_corporate_actions"):
+        sort = tools[name]["properties"]["sort"]
+        assert "allOf" not in sort, f"{name}.sort still wraps allOf"
+        assert sort["enum"] == ["asc", "desc"], f"{name}.sort lost its enum"


### PR DESCRIPTION
## Summary
- FastMCP wraps query-parameter enums in a one-branch `allOf`. Clients that do not merge `allOf` never see `asc`/`desc` on sort parameters.
- Flatten those wrappers at `tools/list` time. A one-branch `allOf` is an identity, so this does not change what the schema accepts.
- This is not a Gemini adapter. MCP servers emit JSON Schema; vendor subsets belong in the host. Related discussion: #71.

## Test plan
- [x] Unit tests for merge, multi-branch leave-alone, nested properties, and literal data
- [x] Server test that `get_option_bars`, `get_option_trades`, and `get_corporate_actions` advertise `sort.enum == ["asc", "desc"]`
- [x] Existing construction / integrity / trust-boundary tests still pass