### PR TITLE
fix: pin FastMCP below 4.0 to stop uvx startup crash

### DIFF
--- a/.well-known/mcp/manifest.json
+++ b/.well-known/mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "GitHub MCP Registry Manifest",
   "_location": "/.well-known/mcp/manifest.json",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "schema_version": "0.2.0",
   "manifest_version": "0.3",
   "name": "alpaca-mcp-server",

--- a/charts/alpaca-mcp-server/Chart.yaml
+++ b/charts/alpaca-mcp-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.3.0"
+appVersion: "2.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "alpaca-mcp-server"
-version = "2.3.0"
+version = "2.3.1"
 description = "Alpaca Trading API integration for Model Context Protocol (MCP)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastmcp>=3.1.0",
+    "fastmcp>=3.1.0,<4",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "click>=8.1.0",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/alpacahq/alpaca-mcp-server",
     "source": "github"
   },
-  "version": "2.3.0",
+  "version": "2.3.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "alpaca-mcp-server",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/server.yaml
+++ b/server.yaml
@@ -82,7 +82,7 @@ config:
 metadata:
   license: MIT
   maintainer: Alpaca <https://alpaca.markets/contact>
-  version: "2.3.0"
+  version: "2.3.1"
 
   docker:
     transport: stdio

--- a/src/alpaca_mcp_server/__init__.py
+++ b/src/alpaca_mcp_server/__init__.py
@@ -12,7 +12,7 @@ Key Features:
 - Corporate actions and market calendar
 """
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __author__ = "Alpaca"
 __license__ = "MIT"
 __description__ = "Alpaca Trading API integration for Model Context Protocol (MCP)"

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "alpaca-mcp-server"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -41,7 +41,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
-    { name = "fastmcp", specifier = ">=3.1.0" },
+    { name = "fastmcp", specifier = ">=3.1.0,<4" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary

`uvx alpaca-mcp-server` has been crashing since FastMCP 4.0.0 shipped. 2.3.0 declared `fastmcp>=3.1.0` with no upper bound, so `uvx` pulls 4.0 and dies on `from fastmcp.tools.tool import ToolResult`.

Pin FastMCP to `>=3.1.0,<4` and bump to 2.3.1. A proper release to migrate to FastMCP v4 will follow.

Until 2.3.1 is on PyPI, the workaround is `uvx --with 'fastmcp>=3.1.0,<4' alpaca-mcp-server`.

## Testing

- [x] Core tests: `uv run --extra dev pytest tests/test_integrity.py tests/test_server_construction.py`
- [x] `uvx --from . --refresh alpaca-mcp-server --transport streamable-http` starts on this branch
- [x] Same command on `main` still crashes