### PR TITLE
feat: add live trading opt-in safety gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,27 +244,31 @@ Add to your MCP client config:
 All configuration is through environment variables set in your MCP client config. No files are written to disk.
 
 
-| Variable             | Required | Default | Description                                |
-| -------------------- | -------- | ------- | ------------------------------------------ |
-| `ALPACA_API_KEY`     | Yes      | —       | Your Alpaca API key                        |
-| `ALPACA_SECRET_KEY`  | Yes      | —       | Your Alpaca secret key                     |
-| `ALPACA_PAPER_TRADE` | No       | `true`  | Set to `false` for live trading            |
-| `ALPACA_TOOLSETS`    | No       | all     | Comma-separated list of toolsets to enable |
+| Variable                    | Required | Default | Description                                                          |
+| --------------------------- | -------- | ------- | -------------------------------------------------------------------- |
+| `ALPACA_API_KEY`            | Yes      | —       | Your Alpaca API key                                                  |
+| `ALPACA_SECRET_KEY`         | Yes      | —       | Your Alpaca secret key                                               |
+| `ALPACA_PAPER_TRADE`        | No       | `true`  | Keep `true` for paper mode; set to `false` only when opting into live |
+| `ALPACA_ALLOW_LIVE_TRADING` | No       | `false` | Required alongside `ALPACA_PAPER_TRADE=false` before live mode starts |
+| `ALPACA_TOOLSETS`           | No       | all     | Comma-separated list of toolsets to enable                           |
 
 
 ### Switching to Live Trading
 
-Update the `env` block in your MCP client config and restart:
+Update the `env` block in your MCP client config and restart. Live mode is blocked unless you opt in explicitly:
 
 ```json
 {
   "env": {
     "ALPACA_API_KEY": "your_live_api_key",
     "ALPACA_SECRET_KEY": "your_live_secret_key",
-    "ALPACA_PAPER_TRADE": "false"
+    "ALPACA_PAPER_TRADE": "false",
+    "ALPACA_ALLOW_LIVE_TRADING": "true"
   }
 }
 ```
+
+If `ALPACA_PAPER_TRADE=false` is set without `ALPACA_ALLOW_LIVE_TRADING=true`, the server exits with a configuration error instead of connecting to the live trading API accidentally.
 
 ### Toolset Filtering
 
@@ -573,7 +577,8 @@ alpaca-mcp-server/
 ## Troubleshooting
 
 - **uv/uvx not found**: Install uv from the official guide ([https://docs.astral.sh/uv/getting-started/installation/](https://docs.astral.sh/uv/getting-started/installation/)) and then restart your terminal so `uv`/`uvx` are on PATH.
-- **Credentials missing**: Set `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` in the client's `env` block. Paper mode default is `ALPACA_PAPER_TRADE = True`.
+- **Credentials missing**: Set `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` in the client's `env` block. Paper mode default is `ALPACA_PAPER_TRADE=true`.
+- **Live mode won't start**: Set both `ALPACA_PAPER_TRADE=false` and `ALPACA_ALLOW_LIVE_TRADING=true`. Leaving out the second flag keeps the server in its paper-first safe default.
 - **Client didn't pick up new config**: Restart the client (Cursor, Claude Desktop, VS Code) after changes.
 - **HTTP port conflicts**: If using `--transport streamable-http`, change `--port` to a free port.
 

--- a/src/alpaca_mcp_server/cli.py
+++ b/src/alpaca_mcp_server/cli.py
@@ -57,9 +57,13 @@ def main(transport: str, host: str, port: int, env_file: Optional[Path]):
         )
         sys.exit(1)
 
-    from .server import build_server
+    from .server import LiveTradingDisabledError, build_server
 
-    server = build_server()
+    try:
+        server = build_server()
+    except LiveTradingDisabledError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
 
     if transport == "stdio":
         server.run(transport="stdio")

--- a/src/alpaca_mcp_server/server.py
+++ b/src/alpaca_mcp_server/server.py
@@ -31,6 +31,7 @@ TRADING_API_BASE_URLS = {
     "live": "https://api.alpaca.markets",
 }
 MARKET_DATA_BASE_URL = "https://data.alpaca.markets"
+LIVE_TRADING_OPT_IN_ENV = "ALPACA_ALLOW_LIVE_TRADING"
 
 
 def strip_v_from_version(release_version: str) -> str:
@@ -113,8 +114,26 @@ def _build_auth_headers() -> dict[str, str]:
     return headers
 
 
+class LiveTradingDisabledError(ValueError):
+    """Raised when live trading is requested without explicit opt-in."""
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"true", "1", "yes"}
+
+
 def _get_trading_base_url() -> str:
-    paper = os.environ.get("ALPACA_PAPER_TRADE", "true").lower() in ("true", "1", "yes")
+    paper = _env_flag("ALPACA_PAPER_TRADE", True)
+    if not paper and not _env_flag(LIVE_TRADING_OPT_IN_ENV, False):
+        raise LiveTradingDisabledError(
+            "Live trading requested but not enabled. "
+            "Leave ALPACA_PAPER_TRADE=true for paper trading, or set "
+            f"{LIVE_TRADING_OPT_IN_ENV}=true alongside ALPACA_PAPER_TRADE=false "
+            "to opt in explicitly."
+        )
     return TRADING_API_BASE_URLS["paper" if paper else "live"]
 
 

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from click.testing import CliRunner
 from fastmcp.client import Client
 
 from alpaca_mcp_server.readme_docs import (
@@ -24,11 +25,14 @@ from alpaca_mcp_server.readme_docs import (
     README_DOC_TOOL_NAMES,
     ReadMeClientFactory,
 )
+from alpaca_mcp_server.cli import main as cli_main
 from alpaca_mcp_server.security import DATA_KEY, SECURITY_KEY
 from alpaca_mcp_server.server import (
     _build_auth_headers,
+    _get_trading_base_url,
     _make_api_client,
     _strip_openapi_vendor_extensions,
+    LiveTradingDisabledError,
     build_server,
     get_mcp_user_agent,
     strip_v_from_version,
@@ -300,6 +304,37 @@ async def test_empty_user_agent_opts_out():
         async with _make_api_client("https://example.com", _build_auth_headers()) as client:
             request = client.build_request("GET", "/")
     assert "User-Agent" not in request.headers
+
+
+def test_live_trading_requires_explicit_opt_in() -> None:
+    env = {**DUMMY_ENV, "ALPACA_PAPER_TRADE": "false"}
+    with patch.dict(os.environ, env, clear=True):
+        with pytest.raises(LiveTradingDisabledError, match="ALPACA_ALLOW_LIVE_TRADING"):
+            _get_trading_base_url()
+
+
+def test_live_trading_uses_live_base_url_when_opted_in() -> None:
+    env = {
+        **DUMMY_ENV,
+        "ALPACA_PAPER_TRADE": "false",
+        "ALPACA_ALLOW_LIVE_TRADING": "true",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert _get_trading_base_url() == "https://api.alpaca.markets"
+
+
+def test_cli_surfaces_live_trading_opt_in_error() -> None:
+    runner = CliRunner()
+    env = {
+        "ALPACA_API_KEY": "test-key",
+        "ALPACA_SECRET_KEY": "test-secret",
+        "ALPACA_PAPER_TRADE": "false",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        result = runner.invoke(cli_main, [])
+
+    assert result.exit_code == 1
+    assert "ALPACA_ALLOW_LIVE_TRADING=true" in result.output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implement explicit opt-in for live trading to prevent accidental real-money trading.

## Summary
- Paper mode (ALPACA_PAPER_TRADE=true) is the safe default
- Live mode requires dual-flag opt-in: ALPACA_PAPER_TRADE=false + ALPACA_ALLOW_LIVE_TRADING=true
- Server raises LiveTradingDisabledError at startup if live mode attempted without opt-in
- CLI surfaces configuration error with clear guidance

## Changes
- Add LiveTradingDisabledError exception to server.py
- Add _env_flag() helper for safe boolean env parsing
- Modify _get_trading_base_url() to enforce explicit opt-in
- Update CLI error handling
- Add comprehensive README documentation
- Add 3 targeted tests verifying opt-in enforcement

## Testing
- All 27 tests pass (test_integrity.py, test_server_construction.py)
- Tested with ALPACA_PAPER_TRADE=false without ALPACA_ALLOW_LIVE_TRADING (raises error)
- Tested with both flags set (uses live endpoint)
- Tested CLI error message surface (clear and actionable)

The dual-flag requirement prevents accidental live trading. This keeps real-money trading deliberate and explicit.