### PR TITLE
fix: accept multi-leg `legs` sent as a JSON string (#97)

### DIFF
--- a/src/alpaca_mcp_server/overrides.py
+++ b/src/alpaca_mcp_server/overrides.py
@@ -8,10 +8,12 @@ tools with curated parameters per asset class.
 
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import Annotated, Optional
 
 import httpx
 from fastmcp import FastMCP
+from pydantic import BeforeValidator
 
 
 def _error(message: str, **extra: object) -> dict:
@@ -19,6 +21,33 @@ def _error(message: str, **extra: object) -> dict:
     err: dict = {"message": message}
     err.update(extra)
     return {"error": err}
+
+
+def _parse_legs(value: object) -> object:
+    """Accept `legs` as an array, or as the JSON string some clients send.
+
+    Several MCP clients serialise nested array arguments to a string before
+    the call reaches the server, so a well-formed multi-leg request arrives
+    as ``'[{"symbol": ...}]'``. Pydantic then rejects it with "Input should
+    be a valid list" before ``place_option_order`` runs, which makes every
+    spread, straddle and condor unplaceable through this tool while
+    single-leg orders on the same tool work fine.
+
+    Running as a BeforeValidator keeps the advertised JSON schema an array,
+    so clients that already send one are completely unaffected.
+
+    A string that is not valid JSON is returned untouched, so pydantic still
+    produces its own error rather than one invented here.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+Legs = Annotated[Optional[list[dict]], BeforeValidator(_parse_legs)]
 
 
 async def _post_order(client: httpx.AsyncClient, body: dict) -> dict:
@@ -265,7 +294,7 @@ def register_order_tools(
         limit_price: Optional[str] = None,
         client_order_id: Optional[str] = None,
         order_class: Optional[str] = None,
-        legs: Optional[list[dict]] = None,
+        legs: Legs = None,
     ) -> dict:
         """Place an options order (single-leg or multi-leg).
 

--- a/tests/test_server_construction.py
+++ b/tests/test_server_construction.py
@@ -24,6 +24,7 @@ from alpaca_mcp_server.readme_docs import (
     README_DOC_TOOL_NAMES,
     ReadMeClientFactory,
 )
+from alpaca_mcp_server.overrides import _parse_legs
 from alpaca_mcp_server.security import DATA_KEY, SECURITY_KEY
 from alpaca_mcp_server.server import (
     _build_auth_headers,
@@ -674,3 +675,71 @@ async def test_toolset_filtering():
     assert "place_stock_order" not in names
     assert "get_stock_bars" not in names
     assert README_DOC_TOOL_NAMES <= names
+
+
+# --- multi-leg legs coercion (issue #97) ----------------------------------
+
+MLEG_LEGS = [
+    {"symbol": "SPY260731P00395000", "ratio_qty": "1", "side": "sell",
+     "position_intent": "sell_to_open"},
+    {"symbol": "SPY260731P00380000", "ratio_qty": "1", "side": "buy",
+     "position_intent": "buy_to_open"},
+]
+
+
+async def _place_option_order(args: dict) -> dict:
+    """Call place_option_order with the network stubbed, returning the request
+    body the override built."""
+    captured: dict = {}
+
+    async def fake_post_order(client: Any, body: dict) -> dict:
+        captured.update(body)
+        return {"id": "stub", "status": "accepted"}
+
+    with patch.dict(os.environ, DUMMY_ENV, clear=False):
+        server = build_server()
+    with patch("alpaca_mcp_server.overrides._post_order", fake_post_order):
+        async with Client(transport=server) as c:
+            await c.call_tool("place_option_order", args)
+    return captured
+
+
+def test_parse_legs_accepts_a_json_string():
+    """Several MCP clients serialise nested arrays before the call reaches the
+    server, so a well-formed multi-leg request arrives as a string."""
+    assert _parse_legs(json.dumps(MLEG_LEGS)) == MLEG_LEGS
+
+
+def test_parse_legs_passes_arrays_through_untouched():
+    assert _parse_legs(MLEG_LEGS) == MLEG_LEGS
+    assert _parse_legs(None) is None
+
+
+def test_parse_legs_leaves_unparseable_strings_for_pydantic():
+    """Returning the string unchanged keeps pydantic's own error message
+    instead of inventing a different one."""
+    assert _parse_legs("not json") == "not json"
+
+
+async def test_multi_leg_order_accepts_legs_as_array_or_string():
+    """Issue #97: legs arriving as a JSON string was rejected with "Input
+    should be a valid list" before the override ran, making every spread and
+    condor unplaceable while single-leg orders on the same tool worked."""
+    base = {"qty": "1", "order_class": "mleg", "type": "limit",
+            "limit_price": "-0.01", "time_in_force": "day"}
+    as_array = await _place_option_order({**base, "legs": MLEG_LEGS})
+    as_string = await _place_option_order({**base, "legs": json.dumps(MLEG_LEGS)})
+
+    assert as_array["legs"] == MLEG_LEGS
+    assert as_string == as_array, "both input forms must build the same order"
+
+
+async def test_multi_leg_legs_schema_is_still_advertised_as_an_array():
+    """The coercion runs as a BeforeValidator specifically so the advertised
+    schema does not change. If legs ever becomes a string/array union, clients
+    and models start being told a string is acceptable."""
+    tools = await _list_tools()
+    legs = next(t for t in tools
+                if t.name == "place_option_order").inputSchema["properties"]["legs"]
+    types = {branch.get("type") for branch in legs["anyOf"]}
+    assert types == {"array", "null"}, f"legs schema widened to {types}"


### PR DESCRIPTION
Fixes #97.

## The problem

`place_option_order` cannot place any multi-leg order through several MCP clients. Those clients serialise nested array arguments to a string before the call reaches the server, so a well-formed request arrives as:

```json
{"legs": "[{\"symbol\": \"SPY260731P00395000\", \"ratio_qty\": \"1\", \"side\": \"sell\", \"position_intent\": \"sell_to_open\"}]"}
```

Pydantic rejects that with `Input should be a valid list` **before** `place_option_order` runs, so the override never sees it. The failure is specific to nested arrays — single-leg option orders through the same tool are unaffected, which is why this reads as "multi-leg is broken" rather than "the tool is broken".

Net effect: every spread, straddle and condor is unplaceable through this server.

## The fix

Coerce in a `BeforeValidator` rather than widening the annotation to `Union[str, list[dict]]`:

```python
Legs = Annotated[Optional[list[dict]], BeforeValidator(_parse_legs)]
```

The union was the tempting one-liner, but it changes the **advertised JSON schema** — and that schema is what clients and the model read to decide what to send. Widening it tells every well-behaved client that a string is an acceptable `legs` value, which is the opposite of the intent. A `BeforeValidator` runs before validation while leaving the published schema byte-identical, so clients already sending an array see no change at all.

A string that is not valid JSON is returned untouched, so pydantic still raises its own error rather than a different one invented here.

## Tests

Four cases added to `tests/test_server_construction.py`:

- `_parse_legs` accepts a JSON string, passes arrays and `None` through untouched, and leaves unparseable strings for pydantic
- an end-to-end call through `Client(transport=server)` with `_post_order` stubbed, asserting **both input forms build an identical request body**
- the advertised schema for `legs` is still `{array, null}` — this fails if anyone later widens the annotation to a union

`46 passed, 54 skipped` locally (the skips are the credentialed integration tests). Unwiring `legs: Legs` while leaving the helper in place fails exactly the end-to-end test, so the test is wired to the behaviour and not to the helper.

## One note on the issue text

The issue also reports that the `time_in_force` docstring is wrong. As far as I can tell that part is **not** a bug — the bundled spec says `Options trading: day.`, which is what the docstring reflects. This PR deliberately changes nothing there.

## How I hit it

Found while running an options agent against the Alpaca paper API. The same 4-leg SPY condor that fails here is accepted by the Alpaca CLI (`status: accepted, order_class: mleg`), which is what narrowed it to argument serialisation rather than the order payload.